### PR TITLE
Revert "Transition from deislabs to project-akri (stage 1) [SAME VERSION] [ALLOW INTERMEDIATE BUILDS]"

### DIFF
--- a/.github/workflows/build-opencv-base-container.yml
+++ b/.github/workflows/build-opencv-base-container.yml
@@ -78,7 +78,7 @@ jobs:
         github_event_action: ${{ github.event.action }}
         github_merged: ${{ github.event.pull_request.merged }}
         container_name: ${{ env.AKRI_COMPONENT }}
-        container_prefix: ghcr.io/project-akri/akri
+        container_prefix: ghcr.io/deislabs/akri
         container_registry_base_url: ghcr.io
         container_registry_username: ${{ secrets.crUsername }}
         container_registry_password: ${{ secrets.crPassword }}

--- a/.github/workflows/build-rust-crossbuild-container.yml
+++ b/.github/workflows/build-rust-crossbuild-container.yml
@@ -78,7 +78,7 @@ jobs:
         github_event_action: ${{ github.event.action }}
         github_merged: ${{ github.event.pull_request.merged }}
         container_name: ${{ env.AKRI_COMPONENT }}
-        container_prefix: ghcr.io/project-akri/akri
+        container_prefix: ghcr.io/deislabs/akri
         container_registry_base_url: ghcr.io
         container_registry_username: ${{ secrets.crUsername }}
         container_registry_password: ${{ secrets.crPassword }}

--- a/build/containers/intermediate/Dockerfile.opencvsharp-build
+++ b/build/containers/intermediate/Dockerfile.opencvsharp-build
@@ -14,7 +14,10 @@ FROM mcr.microsoft.com/dotnet/core/aspnet:${PLATFORM_TAG} AS base
 WORKDIR /app
 
 # Link the container to the Akri repository
-LABEL org.opencontainers.image.source https://github.com/project-akri/akri
+LABEL org.opencontainers.image.source https://github.com/deislabs/akri
+
+# Copy over container legal notice
+COPY ./build/container-images-legal-notice.md .
 
 # based on https://xaviergeerinck.com/opencv-in-dotnet-core
 ENV OPENCV_VERSION="4.1.1"

--- a/build/containers/intermediate/Dockerfile.rust-crossbuild-amd64
+++ b/build/containers/intermediate/Dockerfile.rust-crossbuild-amd64
@@ -17,4 +17,7 @@ RUN apt-get update && \
             libv4l-dev libudev-dev
 
 # Link the container to the Akri repository
-LABEL org.opencontainers.image.source https://github.com/project-akri/akri
+LABEL org.opencontainers.image.source https://github.com/deislabs/akri
+
+# Copy over container legal notice
+COPY ./build/container-images-legal-notice.md .

--- a/build/containers/intermediate/Dockerfile.rust-crossbuild-arm32v7
+++ b/build/containers/intermediate/Dockerfile.rust-crossbuild-arm32v7
@@ -22,4 +22,7 @@ RUN sed -i 's/^deb h'/'deb [arch=amd64,i386] h/' /etc/apt/sources.list && \
             libv4l-dev:armhf libudev-dev:armhf
 
 # Link the container to the Akri repository
-LABEL org.opencontainers.image.source https://github.com/project-akri/akri
+LABEL org.opencontainers.image.source https://github.com/deislabs/akri
+
+# Copy over container legal notice
+COPY ./build/container-images-legal-notice.md .

--- a/build/containers/intermediate/Dockerfile.rust-crossbuild-arm64v8
+++ b/build/containers/intermediate/Dockerfile.rust-crossbuild-arm64v8
@@ -22,4 +22,7 @@ RUN sed -i 's/^deb h'/'deb [arch=amd64,i386] h/' /etc/apt/sources.list && \
             libv4l-dev:arm64 libudev-dev:arm64
 
 # Link the container to the Akri repository
-LABEL org.opencontainers.image.source https://github.com/project-akri/akri
+LABEL org.opencontainers.image.source https://github.com/deislabs/akri
+
+# Copy over container legal notice
+COPY ./build/container-images-legal-notice.md .


### PR DESCRIPTION
Reverts project-akri/akri#402

Once merged, the actions did not run in main since the  [SAME VERSION] [ALLOW INTERMEDIATE BUILDS] flags were not maintained in the merged commit ([see action](https://github.com/project-akri/akri/actions/runs/1388232568)). After reverting, the original PR can be put in again.

This is more motivation to address this issue https://github.com/project-akri/akri/issues/334