### PR TITLE
Take 2: Transition from deislabs to project-akri (stage 1) [SAME VERSION] [ALLOW INTERMEDIATE BUILDS]

### DIFF
--- a/.github/workflows/build-opencv-base-container.yml
+++ b/.github/workflows/build-opencv-base-container.yml
@@ -78,7 +78,7 @@ jobs:
         github_event_action: ${{ github.event.action }}
         github_merged: ${{ github.event.pull_request.merged }}
         container_name: ${{ env.AKRI_COMPONENT }}
-        container_prefix: ghcr.io/deislabs/akri
+        container_prefix: ghcr.io/project-akri/akri
         container_registry_base_url: ghcr.io
         container_registry_username: ${{ secrets.crUsername }}
         container_registry_password: ${{ secrets.crPassword }}

--- a/.github/workflows/build-rust-crossbuild-container.yml
+++ b/.github/workflows/build-rust-crossbuild-container.yml
@@ -78,7 +78,7 @@ jobs:
         github_event_action: ${{ github.event.action }}
         github_merged: ${{ github.event.pull_request.merged }}
         container_name: ${{ env.AKRI_COMPONENT }}
-        container_prefix: ghcr.io/deislabs/akri
+        container_prefix: ghcr.io/project-akri/akri
         container_registry_base_url: ghcr.io
         container_registry_username: ${{ secrets.crUsername }}
         container_registry_password: ${{ secrets.crPassword }}

--- a/build/containers/intermediate/Dockerfile.opencvsharp-build
+++ b/build/containers/intermediate/Dockerfile.opencvsharp-build
@@ -14,10 +14,7 @@ FROM mcr.microsoft.com/dotnet/core/aspnet:${PLATFORM_TAG} AS base
 WORKDIR /app
 
 # Link the container to the Akri repository
-LABEL org.opencontainers.image.source https://github.com/deislabs/akri
-
-# Copy over container legal notice
-COPY ./build/container-images-legal-notice.md .
+LABEL org.opencontainers.image.source https://github.com/project-akri/akri
 
 # based on https://xaviergeerinck.com/opencv-in-dotnet-core
 ENV OPENCV_VERSION="4.1.1"

--- a/build/containers/intermediate/Dockerfile.rust-crossbuild-amd64
+++ b/build/containers/intermediate/Dockerfile.rust-crossbuild-amd64
@@ -17,7 +17,4 @@ RUN apt-get update && \
             libv4l-dev libudev-dev
 
 # Link the container to the Akri repository
-LABEL org.opencontainers.image.source https://github.com/deislabs/akri
-
-# Copy over container legal notice
-COPY ./build/container-images-legal-notice.md .
+LABEL org.opencontainers.image.source https://github.com/project-akri/akri

--- a/build/containers/intermediate/Dockerfile.rust-crossbuild-arm32v7
+++ b/build/containers/intermediate/Dockerfile.rust-crossbuild-arm32v7
@@ -22,7 +22,4 @@ RUN sed -i 's/^deb h'/'deb [arch=amd64,i386] h/' /etc/apt/sources.list && \
             libv4l-dev:armhf libudev-dev:armhf
 
 # Link the container to the Akri repository
-LABEL org.opencontainers.image.source https://github.com/deislabs/akri
-
-# Copy over container legal notice
-COPY ./build/container-images-legal-notice.md .
+LABEL org.opencontainers.image.source https://github.com/project-akri/akri

--- a/build/containers/intermediate/Dockerfile.rust-crossbuild-arm64v8
+++ b/build/containers/intermediate/Dockerfile.rust-crossbuild-arm64v8
@@ -22,7 +22,4 @@ RUN sed -i 's/^deb h'/'deb [arch=amd64,i386] h/' /etc/apt/sources.list && \
             libv4l-dev:arm64 libudev-dev:arm64
 
 # Link the container to the Akri repository
-LABEL org.opencontainers.image.source https://github.com/deislabs/akri
-
-# Copy over container legal notice
-COPY ./build/container-images-legal-notice.md .
+LABEL org.opencontainers.image.source https://github.com/project-akri/akri


### PR DESCRIPTION
Same PR as https://github.com/project-akri/akri/pull/402. When merging, this time, ensure `[SAME VERSION] [ALLOW INTERMEDIATE BUILDS]` flags are included in merged commit.

This is the first of 3 PRs to change references of Akri's previous repro (github.com/deislabs/akri) to github.com/project-akri/akri. It must be staged in order to build and push intermediate containers and then final containers to project-akri's ghcr.

PR 1: : Build OpenCV Base and Build Rust CrossBuild
PR 2: Modify remaining workflows to kick off builds and helm charts
PR 3: Remove all remaining documentation and sample references to deislabs/akri