### PR TITLE
migrate from deislabs to project-akri

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,4 +1,4 @@
-[Akri](https://github.com/deislabs/akri) lets you easily expose heterogeneous leaf devices (such as IP cameras and USB devices) as resources in a Kubernetes cluster, while also supporting the exposure of embedded hardware resources such as GPUs and FPGAs. Akri continually detects nodes that have access to these devices and schedules workloads based on them.
+[Akri](https://github.com/project-akri/akri) lets you easily expose heterogeneous leaf devices (such as IP cameras and USB devices) as resources in a Kubernetes cluster, while also supporting the exposure of embedded hardware resources such as GPUs and FPGAs. Akri continually detects nodes that have access to these devices and schedules workloads based on them.
 
 Simply put: you name it, Akri finds it, you use it.
 
@@ -8,7 +8,7 @@ Helm documentation can be found [here](https://github.com/kubernetes/helm).  Onc
 
 First, add Akri Helm charts:
 ```sh
-helm repo add akri-helm-charts https://deislabs.github.io/akri/
+helm repo add akri-helm-charts https://project-akri.github.io/akri/
 ```
 
 Then install Akri in your cluster:
@@ -19,7 +19,7 @@ Akri can be installed by simply accepting the Helm chart defaults.  This will in
 helm install akri akri-helm-charts/akri
 ```
 
-Alternatively, Akri can be configured using specific parameters (find the available parameters in [values.yaml](https://github.com/deislabs/akri/blob/main/deployment/helm/values.yaml)):
+Alternatively, Akri can be configured using specific parameters (find the available parameters in [values.yaml](https://github.com/project-akri/akri/blob/main/deployment/helm/values.yaml)):
 
 ```
 helm install akri akri-helm-charts/akri --set 'param=value' ...

--- a/index.yaml
+++ b/index.yaml
@@ -9,7 +9,7 @@ entries:
     name: akri
     type: application
     urls:
-    - https://deislabs.github.io/akri/akri-0.6.19.tgz
+    - https://project-akri.github.io/akri/akri-0.6.19.tgz
     version: 0.6.19
   - apiVersion: v2
     appVersion: 0.6.5
@@ -19,7 +19,7 @@ entries:
     name: akri
     type: application
     urls:
-    - https://deislabs.github.io/akri/akri-0.6.5.tgz
+    - https://project-akri.github.io/akri/akri-0.6.5.tgz
     version: 0.6.5
   - apiVersion: v2
     appVersion: 0.1.5
@@ -29,7 +29,7 @@ entries:
     name: akri
     type: application
     urls:
-    - https://deislabs.github.io/akri/akri-0.1.5.tgz
+    - https://project-akri.github.io/akri/akri-0.1.5.tgz
     version: 0.1.5
   - apiVersion: v2
     appVersion: 0.0.44
@@ -39,7 +39,7 @@ entries:
     name: akri
     type: application
     urls:
-    - https://deislabs.github.io/akri/akri-0.0.44.tgz
+    - https://project-akri.github.io/akri/akri-0.0.44.tgz
     version: 0.0.44
   - apiVersion: v2
     appVersion: 0.0.36
@@ -49,7 +49,7 @@ entries:
     name: akri
     type: application
     urls:
-    - https://deislabs.github.io/akri/akri-0.0.36.tgz
+    - https://project-akri.github.io/akri/akri-0.0.36.tgz
     version: 0.0.36
   - apiVersion: v2
     appVersion: 0.0.35
@@ -59,7 +59,7 @@ entries:
     name: akri
     type: application
     urls:
-    - https://deislabs.github.io/akri/akri-0.0.35.tgz
+    - https://project-akri.github.io/akri/akri-0.0.35.tgz
     version: 0.0.35
   - apiVersion: v2
     appVersion: 0.0.34
@@ -69,7 +69,7 @@ entries:
     name: akri
     type: application
     urls:
-    - https://deislabs.github.io/akri/akri-0.0.34.tgz
+    - https://project-akri.github.io/akri/akri-0.0.34.tgz
     version: 0.0.34
   akri-dev:
   - apiVersion: v2
@@ -80,7 +80,7 @@ entries:
     name: akri-dev
     type: application
     urls:
-    - https://deislabs.github.io/akri/akri-dev-0.6.20.tgz
+    - https://project-akri.github.io/akri/akri-dev-0.6.20.tgz
     version: 0.6.20
   - apiVersion: v2
     appVersion: 0.6.19
@@ -90,7 +90,7 @@ entries:
     name: akri-dev
     type: application
     urls:
-    - https://deislabs.github.io/akri/akri-dev-0.6.19.tgz
+    - https://project-akri.github.io/akri/akri-dev-0.6.19.tgz
     version: 0.6.19
   - apiVersion: v2
     appVersion: 0.6.18
@@ -100,7 +100,7 @@ entries:
     name: akri-dev
     type: application
     urls:
-    - https://deislabs.github.io/akri/akri-dev-0.6.18.tgz
+    - https://project-akri.github.io/akri/akri-dev-0.6.18.tgz
     version: 0.6.18
   - apiVersion: v2
     appVersion: 0.6.17
@@ -110,7 +110,7 @@ entries:
     name: akri-dev
     type: application
     urls:
-    - https://deislabs.github.io/akri/akri-dev-0.6.17.tgz
+    - https://project-akri.github.io/akri/akri-dev-0.6.17.tgz
     version: 0.6.17
   - apiVersion: v2
     appVersion: 0.6.16
@@ -120,7 +120,7 @@ entries:
     name: akri-dev
     type: application
     urls:
-    - https://deislabs.github.io/akri/akri-dev-0.6.16.tgz
+    - https://project-akri.github.io/akri/akri-dev-0.6.16.tgz
     version: 0.6.16
   - apiVersion: v2
     appVersion: 0.6.15
@@ -130,7 +130,7 @@ entries:
     name: akri-dev
     type: application
     urls:
-    - https://deislabs.github.io/akri/akri-dev-0.6.15.tgz
+    - https://project-akri.github.io/akri/akri-dev-0.6.15.tgz
     version: 0.6.15
   - apiVersion: v2
     appVersion: 0.6.14
@@ -140,7 +140,7 @@ entries:
     name: akri-dev
     type: application
     urls:
-    - https://deislabs.github.io/akri/akri-dev-0.6.14.tgz
+    - https://project-akri.github.io/akri/akri-dev-0.6.14.tgz
     version: 0.6.14
   - apiVersion: v2
     appVersion: 0.6.13
@@ -150,7 +150,7 @@ entries:
     name: akri-dev
     type: application
     urls:
-    - https://deislabs.github.io/akri/akri-dev-0.6.13.tgz
+    - https://project-akri.github.io/akri/akri-dev-0.6.13.tgz
     version: 0.6.13
   - apiVersion: v2
     appVersion: 0.6.12
@@ -160,7 +160,7 @@ entries:
     name: akri-dev
     type: application
     urls:
-    - https://deislabs.github.io/akri/akri-dev-0.6.12.tgz
+    - https://project-akri.github.io/akri/akri-dev-0.6.12.tgz
     version: 0.6.12
   - apiVersion: v2
     appVersion: 0.6.11
@@ -170,7 +170,7 @@ entries:
     name: akri-dev
     type: application
     urls:
-    - https://deislabs.github.io/akri/akri-dev-0.6.11.tgz
+    - https://project-akri.github.io/akri/akri-dev-0.6.11.tgz
     version: 0.6.11
   - apiVersion: v2
     appVersion: 0.6.10
@@ -180,7 +180,7 @@ entries:
     name: akri-dev
     type: application
     urls:
-    - https://deislabs.github.io/akri/akri-dev-0.6.10.tgz
+    - https://project-akri.github.io/akri/akri-dev-0.6.10.tgz
     version: 0.6.10
   - apiVersion: v2
     appVersion: 0.6.9
@@ -190,7 +190,7 @@ entries:
     name: akri-dev
     type: application
     urls:
-    - https://deislabs.github.io/akri/akri-dev-0.6.9.tgz
+    - https://project-akri.github.io/akri/akri-dev-0.6.9.tgz
     version: 0.6.9
   - apiVersion: v2
     appVersion: 0.6.8
@@ -200,7 +200,7 @@ entries:
     name: akri-dev
     type: application
     urls:
-    - https://deislabs.github.io/akri/akri-dev-0.6.8.tgz
+    - https://project-akri.github.io/akri/akri-dev-0.6.8.tgz
     version: 0.6.8
   - apiVersion: v2
     appVersion: 0.6.7
@@ -210,7 +210,7 @@ entries:
     name: akri-dev
     type: application
     urls:
-    - https://deislabs.github.io/akri/akri-dev-0.6.7.tgz
+    - https://project-akri.github.io/akri/akri-dev-0.6.7.tgz
     version: 0.6.7
   - apiVersion: v2
     appVersion: 0.6.6
@@ -220,7 +220,7 @@ entries:
     name: akri-dev
     type: application
     urls:
-    - https://deislabs.github.io/akri/akri-dev-0.6.6.tgz
+    - https://project-akri.github.io/akri/akri-dev-0.6.6.tgz
     version: 0.6.6
   - apiVersion: v2
     appVersion: 0.6.5
@@ -230,7 +230,7 @@ entries:
     name: akri-dev
     type: application
     urls:
-    - https://deislabs.github.io/akri/akri-dev-0.6.5.tgz
+    - https://project-akri.github.io/akri/akri-dev-0.6.5.tgz
     version: 0.6.5
   - apiVersion: v2
     appVersion: 0.6.4
@@ -240,7 +240,7 @@ entries:
     name: akri-dev
     type: application
     urls:
-    - https://deislabs.github.io/akri/akri-dev-0.6.4.tgz
+    - https://project-akri.github.io/akri/akri-dev-0.6.4.tgz
     version: 0.6.4
   - apiVersion: v2
     appVersion: 0.6.3
@@ -250,7 +250,7 @@ entries:
     name: akri-dev
     type: application
     urls:
-    - https://deislabs.github.io/akri/akri-dev-0.6.3.tgz
+    - https://project-akri.github.io/akri/akri-dev-0.6.3.tgz
     version: 0.6.3
   - apiVersion: v2
     appVersion: 0.6.2
@@ -260,7 +260,7 @@ entries:
     name: akri-dev
     type: application
     urls:
-    - https://deislabs.github.io/akri/akri-dev-0.6.2.tgz
+    - https://project-akri.github.io/akri/akri-dev-0.6.2.tgz
     version: 0.6.2
   - apiVersion: v2
     appVersion: 0.6.1
@@ -270,7 +270,7 @@ entries:
     name: akri-dev
     type: application
     urls:
-    - https://deislabs.github.io/akri/akri-dev-0.6.1.tgz
+    - https://project-akri.github.io/akri/akri-dev-0.6.1.tgz
     version: 0.6.1
   - apiVersion: v2
     appVersion: 0.6.0
@@ -280,7 +280,7 @@ entries:
     name: akri-dev
     type: application
     urls:
-    - https://deislabs.github.io/akri/akri-dev-0.6.0.tgz
+    - https://project-akri.github.io/akri/akri-dev-0.6.0.tgz
     version: 0.6.0
   - apiVersion: v2
     appVersion: 0.5.0
@@ -290,7 +290,7 @@ entries:
     name: akri-dev
     type: application
     urls:
-    - https://deislabs.github.io/akri/akri-dev-0.5.0.tgz
+    - https://project-akri.github.io/akri/akri-dev-0.5.0.tgz
     version: 0.5.0
   - apiVersion: v2
     appVersion: 0.4.6
@@ -300,7 +300,7 @@ entries:
     name: akri-dev
     type: application
     urls:
-    - https://deislabs.github.io/akri/akri-dev-0.4.6.tgz
+    - https://project-akri.github.io/akri/akri-dev-0.4.6.tgz
     version: 0.4.6
   - apiVersion: v2
     appVersion: 0.4.5
@@ -310,7 +310,7 @@ entries:
     name: akri-dev
     type: application
     urls:
-    - https://deislabs.github.io/akri/akri-dev-0.4.5.tgz
+    - https://project-akri.github.io/akri/akri-dev-0.4.5.tgz
     version: 0.4.5
   - apiVersion: v2
     appVersion: 0.4.4
@@ -320,7 +320,7 @@ entries:
     name: akri-dev
     type: application
     urls:
-    - https://deislabs.github.io/akri/akri-dev-0.4.4.tgz
+    - https://project-akri.github.io/akri/akri-dev-0.4.4.tgz
     version: 0.4.4
   - apiVersion: v2
     appVersion: 0.4.3
@@ -330,7 +330,7 @@ entries:
     name: akri-dev
     type: application
     urls:
-    - https://deislabs.github.io/akri/akri-dev-0.4.3.tgz
+    - https://project-akri.github.io/akri/akri-dev-0.4.3.tgz
     version: 0.4.3
   - apiVersion: v2
     appVersion: 0.4.2
@@ -340,7 +340,7 @@ entries:
     name: akri-dev
     type: application
     urls:
-    - https://deislabs.github.io/akri/akri-dev-0.4.2.tgz
+    - https://project-akri.github.io/akri/akri-dev-0.4.2.tgz
     version: 0.4.2
   - apiVersion: v2
     appVersion: 0.4.1
@@ -350,7 +350,7 @@ entries:
     name: akri-dev
     type: application
     urls:
-    - https://deislabs.github.io/akri/akri-dev-0.4.1.tgz
+    - https://project-akri.github.io/akri/akri-dev-0.4.1.tgz
     version: 0.4.1
   - apiVersion: v2
     appVersion: 0.4.0
@@ -360,7 +360,7 @@ entries:
     name: akri-dev
     type: application
     urls:
-    - https://deislabs.github.io/akri/akri-dev-0.4.0.tgz
+    - https://project-akri.github.io/akri/akri-dev-0.4.0.tgz
     version: 0.4.0
   - apiVersion: v2
     appVersion: 0.3.2
@@ -370,7 +370,7 @@ entries:
     name: akri-dev
     type: application
     urls:
-    - https://deislabs.github.io/akri/akri-dev-0.3.2.tgz
+    - https://project-akri.github.io/akri/akri-dev-0.3.2.tgz
     version: 0.3.2
   - apiVersion: v2
     appVersion: 0.3.1
@@ -380,7 +380,7 @@ entries:
     name: akri-dev
     type: application
     urls:
-    - https://deislabs.github.io/akri/akri-dev-0.3.1.tgz
+    - https://project-akri.github.io/akri/akri-dev-0.3.1.tgz
     version: 0.3.1
   - apiVersion: v2
     appVersion: 0.3.0
@@ -390,7 +390,7 @@ entries:
     name: akri-dev
     type: application
     urls:
-    - https://deislabs.github.io/akri/akri-dev-0.3.0.tgz
+    - https://project-akri.github.io/akri/akri-dev-0.3.0.tgz
     version: 0.3.0
   - apiVersion: v2
     appVersion: 0.2.3
@@ -400,7 +400,7 @@ entries:
     name: akri-dev
     type: application
     urls:
-    - https://deislabs.github.io/akri/akri-dev-0.2.3.tgz
+    - https://project-akri.github.io/akri/akri-dev-0.2.3.tgz
     version: 0.2.3
   - apiVersion: v2
     appVersion: 0.2.2
@@ -410,7 +410,7 @@ entries:
     name: akri-dev
     type: application
     urls:
-    - https://deislabs.github.io/akri/akri-dev-0.2.2.tgz
+    - https://project-akri.github.io/akri/akri-dev-0.2.2.tgz
     version: 0.2.2
   - apiVersion: v2
     appVersion: 0.2.1
@@ -420,7 +420,7 @@ entries:
     name: akri-dev
     type: application
     urls:
-    - https://deislabs.github.io/akri/akri-dev-0.2.1.tgz
+    - https://project-akri.github.io/akri/akri-dev-0.2.1.tgz
     version: 0.2.1
   - apiVersion: v2
     appVersion: 0.2.0
@@ -430,7 +430,7 @@ entries:
     name: akri-dev
     type: application
     urls:
-    - https://deislabs.github.io/akri/akri-dev-0.2.0.tgz
+    - https://project-akri.github.io/akri/akri-dev-0.2.0.tgz
     version: 0.2.0
   - apiVersion: v2
     appVersion: 0.1.18
@@ -440,7 +440,7 @@ entries:
     name: akri-dev
     type: application
     urls:
-    - https://deislabs.github.io/akri/akri-dev-0.1.18.tgz
+    - https://project-akri.github.io/akri/akri-dev-0.1.18.tgz
     version: 0.1.18
   - apiVersion: v2
     appVersion: 0.1.17
@@ -450,7 +450,7 @@ entries:
     name: akri-dev
     type: application
     urls:
-    - https://deislabs.github.io/akri/akri-dev-0.1.17.tgz
+    - https://project-akri.github.io/akri/akri-dev-0.1.17.tgz
     version: 0.1.17
   - apiVersion: v2
     appVersion: 0.1.16
@@ -460,7 +460,7 @@ entries:
     name: akri-dev
     type: application
     urls:
-    - https://deislabs.github.io/akri/akri-dev-0.1.16.tgz
+    - https://project-akri.github.io/akri/akri-dev-0.1.16.tgz
     version: 0.1.16
   - apiVersion: v2
     appVersion: 0.1.15
@@ -470,7 +470,7 @@ entries:
     name: akri-dev
     type: application
     urls:
-    - https://deislabs.github.io/akri/akri-dev-0.1.15.tgz
+    - https://project-akri.github.io/akri/akri-dev-0.1.15.tgz
     version: 0.1.15
   - apiVersion: v2
     appVersion: 0.1.14
@@ -480,7 +480,7 @@ entries:
     name: akri-dev
     type: application
     urls:
-    - https://deislabs.github.io/akri/akri-dev-0.1.14.tgz
+    - https://project-akri.github.io/akri/akri-dev-0.1.14.tgz
     version: 0.1.14
   - apiVersion: v2
     appVersion: 0.1.13
@@ -490,7 +490,7 @@ entries:
     name: akri-dev
     type: application
     urls:
-    - https://deislabs.github.io/akri/akri-dev-0.1.13.tgz
+    - https://project-akri.github.io/akri/akri-dev-0.1.13.tgz
     version: 0.1.13
   - apiVersion: v2
     appVersion: 0.1.12
@@ -500,7 +500,7 @@ entries:
     name: akri-dev
     type: application
     urls:
-    - https://deislabs.github.io/akri/akri-dev-0.1.12.tgz
+    - https://project-akri.github.io/akri/akri-dev-0.1.12.tgz
     version: 0.1.12
   - apiVersion: v2
     appVersion: 0.1.11
@@ -510,7 +510,7 @@ entries:
     name: akri-dev
     type: application
     urls:
-    - https://deislabs.github.io/akri/akri-dev-0.1.11.tgz
+    - https://project-akri.github.io/akri/akri-dev-0.1.11.tgz
     version: 0.1.11
   - apiVersion: v2
     appVersion: 0.1.10
@@ -520,7 +520,7 @@ entries:
     name: akri-dev
     type: application
     urls:
-    - https://deislabs.github.io/akri/akri-dev-0.1.10.tgz
+    - https://project-akri.github.io/akri/akri-dev-0.1.10.tgz
     version: 0.1.10
   - apiVersion: v2
     appVersion: 0.1.9
@@ -530,7 +530,7 @@ entries:
     name: akri-dev
     type: application
     urls:
-    - https://deislabs.github.io/akri/akri-dev-0.1.9.tgz
+    - https://project-akri.github.io/akri/akri-dev-0.1.9.tgz
     version: 0.1.9
   - apiVersion: v2
     appVersion: 0.1.8
@@ -540,7 +540,7 @@ entries:
     name: akri-dev
     type: application
     urls:
-    - https://deislabs.github.io/akri/akri-dev-0.1.8.tgz
+    - https://project-akri.github.io/akri/akri-dev-0.1.8.tgz
     version: 0.1.8
   - apiVersion: v2
     appVersion: 0.1.7
@@ -550,7 +550,7 @@ entries:
     name: akri-dev
     type: application
     urls:
-    - https://deislabs.github.io/akri/akri-dev-0.1.7.tgz
+    - https://project-akri.github.io/akri/akri-dev-0.1.7.tgz
     version: 0.1.7
   - apiVersion: v2
     appVersion: 0.1.6
@@ -560,7 +560,7 @@ entries:
     name: akri-dev
     type: application
     urls:
-    - https://deislabs.github.io/akri/akri-dev-0.1.6.tgz
+    - https://project-akri.github.io/akri/akri-dev-0.1.6.tgz
     version: 0.1.6
   - apiVersion: v2
     appVersion: 0.1.5
@@ -570,7 +570,7 @@ entries:
     name: akri-dev
     type: application
     urls:
-    - https://deislabs.github.io/akri/akri-dev-0.1.5.tgz
+    - https://project-akri.github.io/akri/akri-dev-0.1.5.tgz
     version: 0.1.5
   - apiVersion: v2
     appVersion: 0.1.4
@@ -580,7 +580,7 @@ entries:
     name: akri-dev
     type: application
     urls:
-    - https://deislabs.github.io/akri/akri-dev-0.1.4.tgz
+    - https://project-akri.github.io/akri/akri-dev-0.1.4.tgz
     version: 0.1.4
   - apiVersion: v2
     appVersion: 0.1.3
@@ -590,7 +590,7 @@ entries:
     name: akri-dev
     type: application
     urls:
-    - https://deislabs.github.io/akri/akri-dev-0.1.3.tgz
+    - https://project-akri.github.io/akri/akri-dev-0.1.3.tgz
     version: 0.1.3
   - apiVersion: v2
     appVersion: 0.1.2
@@ -600,7 +600,7 @@ entries:
     name: akri-dev
     type: application
     urls:
-    - https://deislabs.github.io/akri/akri-dev-0.1.2.tgz
+    - https://project-akri.github.io/akri/akri-dev-0.1.2.tgz
     version: 0.1.2
   - apiVersion: v2
     appVersion: 0.1.1
@@ -610,7 +610,7 @@ entries:
     name: akri-dev
     type: application
     urls:
-    - https://deislabs.github.io/akri/akri-dev-0.1.1.tgz
+    - https://project-akri.github.io/akri/akri-dev-0.1.1.tgz
     version: 0.1.1
   - apiVersion: v2
     appVersion: 0.1.0
@@ -620,7 +620,7 @@ entries:
     name: akri-dev
     type: application
     urls:
-    - https://deislabs.github.io/akri/akri-dev-0.1.0.tgz
+    - https://project-akri.github.io/akri/akri-dev-0.1.0.tgz
     version: 0.1.0
   - apiVersion: v2
     appVersion: 0.0.44
@@ -630,7 +630,7 @@ entries:
     name: akri-dev
     type: application
     urls:
-    - https://deislabs.github.io/akri/akri-dev-0.0.44.tgz
+    - https://project-akri.github.io/akri/akri-dev-0.0.44.tgz
     version: 0.0.44
   - apiVersion: v2
     appVersion: 0.0.43
@@ -640,7 +640,7 @@ entries:
     name: akri-dev
     type: application
     urls:
-    - https://deislabs.github.io/akri/akri-dev-0.0.43.tgz
+    - https://project-akri.github.io/akri/akri-dev-0.0.43.tgz
     version: 0.0.43
   - apiVersion: v2
     appVersion: 0.0.42
@@ -650,7 +650,7 @@ entries:
     name: akri-dev
     type: application
     urls:
-    - https://deislabs.github.io/akri/akri-dev-0.0.42.tgz
+    - https://project-akri.github.io/akri/akri-dev-0.0.42.tgz
     version: 0.0.42
   - apiVersion: v2
     appVersion: 0.0.41
@@ -660,7 +660,7 @@ entries:
     name: akri-dev
     type: application
     urls:
-    - https://deislabs.github.io/akri/akri-dev-0.0.41.tgz
+    - https://project-akri.github.io/akri/akri-dev-0.0.41.tgz
     version: 0.0.41
   - apiVersion: v2
     appVersion: 0.0.40
@@ -670,7 +670,7 @@ entries:
     name: akri-dev
     type: application
     urls:
-    - https://deislabs.github.io/akri/akri-dev-0.0.40.tgz
+    - https://project-akri.github.io/akri/akri-dev-0.0.40.tgz
     version: 0.0.40
   - apiVersion: v2
     appVersion: 0.0.39
@@ -680,7 +680,7 @@ entries:
     name: akri-dev
     type: application
     urls:
-    - https://deislabs.github.io/akri/akri-dev-0.0.39.tgz
+    - https://project-akri.github.io/akri/akri-dev-0.0.39.tgz
     version: 0.0.39
   - apiVersion: v2
     appVersion: 0.0.38
@@ -690,7 +690,7 @@ entries:
     name: akri-dev
     type: application
     urls:
-    - https://deislabs.github.io/akri/akri-dev-0.0.38.tgz
+    - https://project-akri.github.io/akri/akri-dev-0.0.38.tgz
     version: 0.0.38
   - apiVersion: v2
     appVersion: 0.0.37
@@ -700,7 +700,7 @@ entries:
     name: akri-dev
     type: application
     urls:
-    - https://deislabs.github.io/akri/akri-dev-0.0.37.tgz
+    - https://project-akri.github.io/akri/akri-dev-0.0.37.tgz
     version: 0.0.37
   - apiVersion: v2
     appVersion: 0.0.36
@@ -710,6 +710,6 @@ entries:
     name: akri-dev
     type: application
     urls:
-    - https://deislabs.github.io/akri/akri-dev-0.0.36.tgz
+    - https://project-akri.github.io/akri/akri-dev-0.0.36.tgz
     version: 0.0.36
 generated: "2021-10-01T23:03:10.260383861Z"


### PR DESCRIPTION
**What this PR does / why we need it**:
gh-pages content was migrated from deislabs.  the index.md and index.yaml files still have content that references deislabs.  this breaks the helm install process.
