### PR TITLE
[SAME VERSION] revert cargo-update

### DIFF
--- a/.github/workflows/auto-update-dependencies.yml
+++ b/.github/workflows/auto-update-dependencies.yml
@@ -30,5 +30,5 @@ jobs:
       uses: romoh/dependencies-autoupdate@v1.1
       with:  
         token: ${{ secrets.AKRI_BOT_TOKEN }}
-        update-command: "'cargo update && cargo test && cargo upgrade --to-lockfile --workspace'"
+        update-command: "'cargo update && cargo test'"
         on-changes-command: "'./version.sh -u -p'"


### PR DESCRIPTION
**What this PR does / why we need it**:
Reverts the use of `cargo update`. This was added to keep toml files in sync with `Cargo.lock` however it doesn't handle pinned dependencies so cannot be used.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR has an associated PR with documentation in [akri-docs](https://github.com/project-akri/akri-docs)
- [ ] this PR contains unit tests
- [ ] added code adheres to standard Rust formatting (`cargo fmt`)
- [ ] code builds properly (`cargo build`)
- [ ] code is free of common mistakes (`cargo clippy`)
- [ ] all Akri tests succeed (`cargo test`)
- [ ] inline documentation builds (`cargo doc`)
- [ ] version has been updated appropriately (`./version.sh`)