### PR TITLE
Execute workloads based on labels instead of flags in PR titles

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 <!--  Thank you for contributing to the Akri repo! Before submitting this PR, please make sure:
 1. Read the Contributing Guide before submitting your PR: https://docs.akri.sh/community/contributing
-2. Decide whether you need to add any flags to your PR title, such as `[SAME VERSION]` if the version should not be changed and your change will trigger the version check workflow. This will cause the workflow to automatically succeed: https://github.com/project-akri/akri/blob/main/.github/workflows/check-versioning.yml
+2. Decide whether you need to add any labels to your PR, such as `same version` if the version should not be changed and your change will trigger the version check workflow. This will cause the workflow to automatically succeed: https://github.com/project-akri/akri/blob/main/.github/workflows/check-versioning.yml
 3. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context. -->
 
 **What this PR does / why we need it**:

--- a/.github/workflows/build-opencv-base-container.yml
+++ b/.github/workflows/build-opencv-base-container.yml
@@ -10,6 +10,7 @@ on:
     - build/intermediate-containers.mk
     - Makefile
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
     branches: [ main ]
     paths:
     - .github/actions/build-intermediate/**
@@ -17,6 +18,9 @@ on:
     - build/containers/intermediate/Dockerfile.opencvsharp-build
     - build/intermediate-containers.mk
     - Makefile
+  issue_comment:
+    types: [created, edited]
+    branches: [ main ]
 
 env:
   AKRI_COMPONENT: opencvsharp-build
@@ -24,10 +28,74 @@ env:
 
 jobs:
 
+  add-same-version-label-to-pr:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'issue_comment' && contains(github.event.comment.body, '/add-same-version-label')
+    steps:
+    - uses: actions/checkout@v2
+    - name: Add same version label
+      uses: actions/github-script@0.9.0
+      if: success()
+      with:
+        github-token: ${{secrets.GITHUB_TOKEN}}
+        script: |
+          github.issues.addLabels({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            labels: ['same version']
+          })
+          github.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: '👋 Added [same version] label :)!'
+          })
+
+  add-build-label-to-pr:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'issue_comment' && contains(github.event.comment.body, '/add-build-dependency-containers-label')
+    steps:
+    - uses: actions/checkout@v2
+    - name: Add build dependency containers label
+      uses: actions/github-script@0.9.0
+      if: success()
+      with:
+        github-token: ${{secrets.GITHUB_TOKEN}}
+        script: |
+          github.issues.addLabels({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            labels: ['build dependency containers']
+          })
+          github.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: '👋 Added [build dependency containers] label :)!'
+          })
+
+  add-label-missing-comment:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && (github.event.action == 'opened') && !contains(github.event.pull_request.labels.*.name, 'build dependency containers')
+    steps:
+    - uses: actions/checkout@v2
+    - name: Add comment about missing build dependency containers label
+      uses: actions/github-script@0.9.0
+      if: success()
+      with:
+        github-token: ${{secrets.GITHUB_TOKEN}}
+        script: |
+          github.issues.createComment({
+            issue_number: context.payload.pull_request.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: 'Hi there, this change should run build dependency containers, but running it will take hours. Do you want to run it? If so, please add label "build dependency containers" by commenting "/add-build-dependency-containers-label".'
+          })
+
   per-arch:
-    if: >-
-      !contains(github.event.pull_request.title, '[IGNORE INTERMEDIATE BUILDS]') &&
-      !contains(github.event.commits[0].message, '[IGNORE INTERMEDIATE BUILDS]')
+    if: contains(github.event.pull_request.labels.*.name, 'build dependency containers')
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -41,21 +109,10 @@ jobs:
       with:
         persist-credentials: false
 
-    - name: Akri intermediate builds are LONG running and should only be run when absolutely needed
-      if: >-
-        !contains(github.event.pull_request.title, '[ALLOW INTERMEDIATE BUILDS]') &&
-        !contains(github.event.commits[0].message, '[ALLOW INTERMEDIATE BUILDS]')
-      run: |
-        echo "Akri intermediate builds are LONG running and should only be run when absolutely needed."
-        echo "Add [IGNORE INTERMEDIATE BUILDS] to first commit message to skip building intermediate containers."
-        echo "Add [ALLOW INTERMEDIATE BUILDS] to first commit message if needed."
-        exit 1
-
-    # Only run build version change check if PR title and Merge commit message do NOT contain "[SAME VERSION]"
+    # Only run build version change check if PR does not have "same version" label
     - if: >-
         startsWith(github.event_name, 'pull_request') &&
-        !contains(github.event.pull_request.title, '[SAME VERSION]') &&
-        !contains(github.event.commits[0].message, '[SAME VERSION]')
+        !contains(github.event.pull_request.labels.*.name, 'same version')
       name: Ensure that ${{ env.AKRI_COMPONENT }} version has changed
       run: |
         git fetch origin main

--- a/.github/workflows/build-rust-crossbuild-container.yml
+++ b/.github/workflows/build-rust-crossbuild-container.yml
@@ -10,6 +10,7 @@ on:
     - build/intermediate-containers.mk
     - Makefile
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
     branches: [ main ]
     paths:
     - .github/actions/build-intermediate/**
@@ -17,6 +18,9 @@ on:
     - build/containers/intermediate/Dockerfile.rust-crossbuild-*
     - build/intermediate-containers.mk
     - Makefile
+  issue_comment:
+    types: [created, edited]
+    branches: [ main ]
 
 env:
   AKRI_COMPONENT: rust-crossbuild
@@ -24,10 +28,74 @@ env:
 
 jobs:
 
+  add-same-version-label-to-pr:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'issue_comment' && contains(github.event.comment.body, '/add-same-version-label')
+    steps:
+    - uses: actions/checkout@v2
+    - name: Add same version label
+      uses: actions/github-script@0.9.0
+      if: success()
+      with:
+        github-token: ${{secrets.GITHUB_TOKEN}}
+        script: |
+          github.issues.addLabels({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            labels: ['same version']
+          })
+          github.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: '👋 Added [same version] label :)!'
+          })
+
+  add-build-label-to-pr:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'issue_comment' && contains(github.event.comment.body, '/add-build-dependency-containers-label')
+    steps:
+    - uses: actions/checkout@v2
+    - name: Add build dependency containers label
+      uses: actions/github-script@0.9.0
+      if: success()
+      with:
+        github-token: ${{secrets.GITHUB_TOKEN}}
+        script: |
+          github.issues.addLabels({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            labels: ['build dependency containers']
+          })
+          github.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: '👋 Added [build dependency containers] label :)!'
+          })
+
+  add-label-missing-comment:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && (github.event.action == 'opened') && !contains(github.event.pull_request.labels.*.name, 'build dependency containers')
+    steps:
+    - uses: actions/checkout@v2
+    - name: Add comment about missing build dependency containers label
+      uses: actions/github-script@0.9.0
+      if: success()
+      with:
+        github-token: ${{secrets.GITHUB_TOKEN}}
+        script: |
+          github.issues.createComment({
+            issue_number: context.payload.pull_request.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: 'Hi there, this change should run build dependency containers, but running it will take hours. Do you want to run it? If so, please add label "build dependency containers" by commenting "/add-build-dependency-containers-label".'
+          })
+
   per-arch:
-    if: >-
-      !contains(github.event.pull_request.title, '[IGNORE INTERMEDIATE BUILDS]') &&
-      !contains(github.event.commits[0].message, '[IGNORE INTERMEDIATE BUILDS]')
+    if: contains(github.event.pull_request.labels.*.name, 'build dependency containers')
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -41,21 +109,10 @@ jobs:
       with:
         persist-credentials: false
 
-    - name: Akri intermediate builds are LONG running and should only be run when absolutely needed
-      if: >-
-        !contains(github.event.pull_request.title, '[ALLOW INTERMEDIATE BUILDS]') &&
-        !contains(github.event.commits[0].message, '[ALLOW INTERMEDIATE BUILDS]')
-      run: |
-        echo "Akri intermediate builds are LONG running and should only be run when absolutely needed."
-        echo "Add [IGNORE INTERMEDIATE BUILDS] to first commit message to skip building intermediate containers."
-        echo "Add [ALLOW INTERMEDIATE BUILDS] to first commit message if needed."
-        exit 1
-
-    # Only run build version change check if PR title and Merge commit message do NOT contain "[SAME VERSION]"
+    # Only run build version change check if PR does not have "same version" label
     - if: >-
         startsWith(github.event_name, 'pull_request') &&
-        !contains(github.event.pull_request.title, '[SAME VERSION]') &&
-        !contains(github.event.commits[0].message, '[SAME VERSION]')
+        !contains(github.event.pull_request.labels.*.name, 'same version')
       name: Ensure that ${{ env.AKRI_COMPONENT }} version has changed
       run: |
         git fetch origin main

--- a/.github/workflows/check-versioning.yml
+++ b/.github/workflows/check-versioning.yml
@@ -20,6 +20,7 @@ on:
       - scripts/**
       - tests/**
   pull_request:
+    types: [assigned, opened, synchronize, reopened, labeled, unlabeled]
     branches: [ main ]
     paths-ignore:
       - '.gitignore'
@@ -40,6 +41,9 @@ on:
   release:
     types:
       - published
+  issues:
+    types:
+      - labeled
 
 env:
   CARGO_TERM_COLOR: always
@@ -54,14 +58,14 @@ jobs:
       uses: actions/checkout@v2
       with:
         persist-credentials: false
-    
-    # Only run version check for PRs.  If PR title does NOT contain "[SAME VERSION]", then ensure that
+
+    # Only run version check for PRs. If PR does NOT have "same version" label, then ensure that
     # version.txt is different from what is in main.
-    - if: startsWith(github.event_name, 'pull_request') && contains(github.event.pull_request.title, '[SAME VERSION]') == false
-      name: Run version check
+    - if: startsWith(github.event_name, 'pull_request') && !contains(github.event.pull_request.labels.*.name, 'same version')
+      name: Run version check (triggered by "same version" label)
       run: ./version.sh -c
-    # If PR title does contain "[SAME VERSION]", then do not check that version.txt is different from
+    # If PR does have "same version" label, then do not check that version.txt is different from
     # what is in main.
-    - if: startsWith(github.event_name, 'pull_request') && contains(github.event.pull_request.title, '[SAME VERSION]') == true
-      name: Run version check
+    - if: startsWith(github.event_name, 'pull_request') && contains(github.event.pull_request.labels.*.name, 'same version')
+      name: Run version check (skip, triggered by "same version" label)
       run: ./version.sh -c -s


### PR DESCRIPTION
Signed-off-by: vincepnguyen <70007233+vincepnguyen@users.noreply.github.com>

<!--  Thank you for contributing to the Akri repo! Before submitting this PR, please make sure:
1. Read the Contributing Guide before submitting your PR: https://docs.akri.sh/community/contributing
2. Decide whether you need to add any flags to your PR title, such as `[SAME VERSION]` if the version should not be changed and your change will trigger the version check workflow. This will cause the workflow to automatically succeed: https://github.com/project-akri/akri/blob/main/.github/workflows/check-versioning.yml
3. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context. -->

**What this PR does / why we need it**:
Currently, certain workflows are being skipped/executed based on flags set in PR titles. For example, adding [SAME VERSION] to a PR title prevents the version check workflow from running. However, after adding a flag to a title, checks cannot simply be re-run, since they refer to the state of the PR of the last commit. Resultingly, another commit must be pushed to the PR in order for checks to properly register the PR title change (and therefore flag). Running workflows based on labels instead of flags may remove this issue of pushing new commits. This change enables running build/version check based on labels.

The associated PR with documentation in akri-docs is: https://github.com/project-akri/akri-docs/pull/16

**Special notes for your reviewer**:

**If applicable**:
- [x] this PR has an associated PR with documentation in [akri-docs](https://github.com/project-akri/akri-docs)
- [ ] this PR contains unit tests
- [ ] added code adheres to standard Rust formatting (`cargo fmt`)
- [ ] code builds properly (`cargo build`)
- [ ] code is free of common mistakes (`cargo clippy`)
- [ ] all Akri tests succeed (`cargo test`)
- [ ] inline documentation builds (`cargo doc`)
- [ ] version has been updated appropriately (`./version.sh`)
- [x] all commits pass the [DCO bot check](https://probot.github.io/apps/dco/) by being signed off -- see the failing DCO check for instructions on how to retroactively sign commits