### PR TITLE
Install appropriate crictl package based on platform [SAME VERSION]

### DIFF
--- a/build/containers/Dockerfile.agent
+++ b/build/containers/Dockerfile.agent
@@ -2,6 +2,7 @@ ARG PLATFORM=amd64
 ARG CROSS_BUILD_TARGET=x86_64-unknown-linux-gnu
 FROM ${PLATFORM}/debian:buster-slim
 ARG CROSS_BUILD_TARGET
+ARG PLATFORM
 ARG BUILD_TYPE=release
 RUN echo "Creating container based on ${PLATFORM}/debian:buster-slim"
 RUN echo "Using Rust binaries from ${CROSS_BUILD_TARGET}/${BUILD_TYPE}"
@@ -12,11 +13,11 @@ LABEL org.opencontainers.image.source https://github.com/project-akri/akri
 # Install crictl and openssl dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends libssl-dev openssl curl ca-certificates && \
     echo "Container platform target is ${PLATFORM}" && \
-    if [$PLATFORM -eq "arm32v7"] ; \
+    if [ "$PLATFORM" = "arm32v7"] ; \
     then export CRICTL_PLATFORM="arm" ; \
-    elif [$PLATFORM -eq "arm64v8"] ; \
+    elif [ "$PLATFORM" = "arm64v8" ] ; \
     then export CRICTL_PLATFORM="arm64" ; \
-    elif [$PLATFORM -eq "amd64"] ; \
+    elif [ "$PLATFORM" = "amd64" ] ; \
     then export CRICTL_PLATFORM="amd64" ; \
     else echo "no PLATFORM provided. Using amd64 for crictl" && export CRICTL_PLATFORM="amd64" ; \
     fi && \

--- a/build/containers/Dockerfile.agent
+++ b/build/containers/Dockerfile.agent
@@ -11,10 +11,20 @@ LABEL org.opencontainers.image.source https://github.com/project-akri/akri
 
 # Install crictl and openssl dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends libssl-dev openssl curl ca-certificates && \
+    echo "Container platform target is ${PLATFORM}" && \
+    if [$PLATFORM -eq "arm32v7"] ; \
+    then export CRICTL_PLATFORM="arm" ; \
+    elif [$PLATFORM -eq "arm64v8"] ; \
+    then export CRICTL_PLATFORM="arm64" ; \
+    elif [$PLATFORM -eq "amd64"] ; \
+    then export CRICTL_PLATFORM="amd64" ; \
+    else echo "no PLATFORM provided. Using amd64 for crictl" && export CRICTL_PLATFORM="amd64" ; \
+    fi && \
+    echo "CRICTL platform target is ${CRICTL_PLATFORM}" && \
     VERSION="v1.17.0" && \
-    curl -L https://github.com/kubernetes-sigs/cri-tools/releases/download/$VERSION/crictl-$VERSION-linux-amd64.tar.gz --output crictl-$VERSION-linux-amd64.tar.gz && \
-    tar zxvf crictl-$VERSION-linux-amd64.tar.gz -C /usr/local/bin && \
-    rm -f crictl-$VERSION-linux-amd64.tar.gz && \
+    curl -L https://github.com/kubernetes-sigs/cri-tools/releases/download/$VERSION/crictl-$VERSION-linux-$CRICTL_PLATFORM.tar.gz --output crictl.tar.gz && \
+    tar zxvf crictl.tar.gz -C /usr/local/bin && \
+    rm -f crictl.tar.gz && \
     apt-get remove -y curl ca-certificates && apt-get clean
 
 COPY ./target/${CROSS_BUILD_TARGET}/${BUILD_TYPE}/agent /agent

--- a/build/containers/Dockerfile.agent-full
+++ b/build/containers/Dockerfile.agent-full
@@ -1,6 +1,7 @@
 ARG PLATFORM=amd64
 ARG CROSS_BUILD_TARGET=x86_64-unknown-linux-gnu
 FROM ${PLATFORM}/debian:buster-slim
+ARG PLATFORM
 ARG CROSS_BUILD_TARGET
 ARG BUILD_TYPE=release
 RUN echo "Creating container based on ${PLATFORM}/debian:buster-slim"
@@ -11,11 +12,11 @@ LABEL org.opencontainers.image.source https://github.com/project-akri/akri
 
 RUN apt-get update && apt-get install -y --no-install-recommends libssl-dev openssl curl ca-certificates && \
     echo "Container platform target is ${PLATFORM}" && \
-    if [$PLATFORM -eq "arm32v7"] ; \
+    if [ "$PLATFORM" = "arm32v7"] ; \
     then export CRICTL_PLATFORM="arm" ; \
-    elif [$PLATFORM -eq "arm64v8"] ; \
+    elif [ "$PLATFORM" = "arm64v8" ] ; \
     then export CRICTL_PLATFORM="arm64" ; \
-    elif [$PLATFORM -eq "amd64"] ; \
+    elif [ "$PLATFORM" = "amd64" ] ; \
     then export CRICTL_PLATFORM="amd64" ; \
     else echo "no PLATFORM provided. Using amd64 for crictl" && export CRICTL_PLATFORM="amd64" ; \
     fi && \

--- a/build/containers/Dockerfile.agent-full
+++ b/build/containers/Dockerfile.agent-full
@@ -10,10 +10,20 @@ RUN echo "Using Rust binaries from ${CROSS_BUILD_TARGET}/${BUILD_TYPE}"
 LABEL org.opencontainers.image.source https://github.com/project-akri/akri
 
 RUN apt-get update && apt-get install -y --no-install-recommends libssl-dev openssl curl ca-certificates && \
+    echo "Container platform target is ${PLATFORM}" && \
+    if [$PLATFORM -eq "arm32v7"] ; \
+    then export CRICTL_PLATFORM="arm" ; \
+    elif [$PLATFORM -eq "arm64v8"] ; \
+    then export CRICTL_PLATFORM="arm64" ; \
+    elif [$PLATFORM -eq "amd64"] ; \
+    then export CRICTL_PLATFORM="amd64" ; \
+    else echo "no PLATFORM provided. Using amd64 for crictl" && export CRICTL_PLATFORM="amd64" ; \
+    fi && \
+    echo "CRICTL platform target is ${CRICTL_PLATFORM}" && \
     VERSION="v1.17.0" && \
-    curl -L https://github.com/kubernetes-sigs/cri-tools/releases/download/$VERSION/crictl-$VERSION-linux-amd64.tar.gz --output crictl-$VERSION-linux-amd64.tar.gz && \
-    tar zxvf crictl-$VERSION-linux-amd64.tar.gz -C /usr/local/bin && \
-    rm -f crictl-$VERSION-linux-amd64.tar.gz && \
+    curl -L https://github.com/kubernetes-sigs/cri-tools/releases/download/$VERSION/crictl-$VERSION-linux-$CRICTL_PLATFORM.tar.gz --output crictl.tar.gz && \
+    tar zxvf crictl.tar.gz -C /usr/local/bin && \
+    rm -f crictl.tar.gz && \
     apt-get remove -y curl ca-certificates && apt-get clean
     
 COPY ./target/${CROSS_BUILD_TARGET}/${BUILD_TYPE}/agent-full /agent


### PR DESCRIPTION
<!--  Thank you for contributing to the Akri repo! Before submitting this PR, please make sure:
1. Read the Contributing Guide before submitting your PR: https://docs.akri.sh/community/contributing
2. Decide whether you need to add any flags to your PR title, such as `[SAME VERSION]` if the version should not be changed and your change will trigger the version check workflow. This will cause the workflow to automatically succeed: https://github.com/project-akri/akri/blob/main/.github/workflows/check-versioning.yml
3. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context. -->

**What this PR does / why we need it**:
In https://github.com/project-akri/akri/pull/418 PR that adds crictl to the Agent, we did not account for installing different crictl packages based on platform, resulting in [failures building the agent on Arm](https://github.com/project-akri/akri/runs/4301806255?check_suite_focus=true) and end to end tests. 

Using same version in order to create successful builds for the current version (since https://github.com/project-akri/akri/pull/418 was the previously merged PR).

**Special notes for your reviewer**:

**If applicable**:
- [x] all commits pass the [DCO bot check](https://probot.github.io/apps/dco/) by being signed off -- see the failing DCO check for instructions on how to retroactively sign commits