### PR TITLE
Use `wget` Instead of `curl` in CRICTL Installation in Agent [SAME VERSION]

### DIFF
--- a/build/containers/Dockerfile.agent
+++ b/build/containers/Dockerfile.agent
@@ -11,7 +11,7 @@ RUN echo "Using Rust binaries from ${CROSS_BUILD_TARGET}/${BUILD_TYPE}"
 LABEL org.opencontainers.image.source https://github.com/project-akri/akri
 
 # Install crictl and openssl dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends libssl-dev openssl curl ca-certificates && \
+RUN apt-get update && apt-get install -y --no-install-recommends libssl-dev openssl wget ca-certificates && \
     echo "Container platform target is ${PLATFORM}" && \
     if [ "$PLATFORM" = "arm32v7" ] ; \
     then export CRICTL_PLATFORM="arm" ; \
@@ -23,10 +23,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends libssl-dev open
     fi && \
     echo "CRICTL platform target is ${CRICTL_PLATFORM}" && \
     VERSION="v1.17.0" && \
-    curl -L https://github.com/kubernetes-sigs/cri-tools/releases/download/$VERSION/crictl-$VERSION-linux-$CRICTL_PLATFORM.tar.gz --output crictl.tar.gz && \
+    wget https://github.com/kubernetes-sigs/cri-tools/releases/download/$VERSION/crictl-$VERSION-linux-$CRICTL_PLATFORM.tar.gz -O crictl.tar.gz && \
     tar zxvf crictl.tar.gz -C /usr/local/bin && \
     rm -f crictl.tar.gz && \
-    apt-get remove -y curl ca-certificates && apt-get clean
+    apt-get remove -y wget ca-certificates && apt-get clean
 
 COPY ./target/${CROSS_BUILD_TARGET}/${BUILD_TYPE}/agent /agent
 ENV RUST_LOG agent,akri_shared

--- a/build/containers/Dockerfile.agent-full
+++ b/build/containers/Dockerfile.agent-full
@@ -10,7 +10,7 @@ RUN echo "Using Rust binaries from ${CROSS_BUILD_TARGET}/${BUILD_TYPE}"
 # Link the container to the Akri repository
 LABEL org.opencontainers.image.source https://github.com/project-akri/akri
 
-RUN apt-get update && apt-get install -y --no-install-recommends libssl-dev openssl curl ca-certificates && \
+RUN apt-get update && apt-get install -y --no-install-recommends libssl-dev openssl wget ca-certificates && \
     echo "Container platform target is ${PLATFORM}" && \
     if [ "$PLATFORM" = "arm32v7" ] ; \
     then export CRICTL_PLATFORM="arm" ; \
@@ -22,10 +22,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends libssl-dev open
     fi && \
     echo "CRICTL platform target is ${CRICTL_PLATFORM}" && \
     VERSION="v1.17.0" && \
-    curl -L https://github.com/kubernetes-sigs/cri-tools/releases/download/$VERSION/crictl-$VERSION-linux-$CRICTL_PLATFORM.tar.gz --output crictl.tar.gz && \
+    wget https://github.com/kubernetes-sigs/cri-tools/releases/download/$VERSION/crictl-$VERSION-linux-$CRICTL_PLATFORM.tar.gz -O crictl.tar.gz && \
     tar zxvf crictl.tar.gz -C /usr/local/bin && \
     rm -f crictl.tar.gz && \
-    apt-get remove -y curl ca-certificates && apt-get clean
+    apt-get remove -y wget ca-certificates && apt-get clean
     
 COPY ./target/${CROSS_BUILD_TARGET}/${BUILD_TYPE}/agent-full /agent
 ENV RUST_LOG agent,akri_shared,akri_debug_echo


### PR DESCRIPTION
<!--  Thank you for contributing to the Akri repo! Before submitting this PR, please make sure:
1. Read the Contributing Guide before submitting your PR: https://docs.akri.sh/community/contributing
2. Decide whether you need to add any flags to your PR title, such as `[SAME VERSION]` if the version should not be changed and your change will trigger the version check workflow. This will cause the workflow to automatically succeed: https://github.com/project-akri/akri/blob/main/.github/workflows/check-versioning.yml
3. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context. -->

**What this PR does / why we need it**:
Enables getting `crictl` package on armv7 by using `wget` instead of `curl`. Builds off of PRs #433 and #430
