### PR TITLE
Update to latest github action that supports commits signoff

### DIFF
--- a/.github/workflows/auto-update-dependencies.yml
+++ b/.github/workflows/auto-update-dependencies.yml
@@ -27,7 +27,7 @@ jobs:
         cargo install cargo-edit
     
     - name: Check for dependency updates
-      uses: romoh/dependencies-autoupdate@v1.1
+      uses: romoh/dependencies-autoupdate@v1.2
       with:  
         token: ${{ secrets.AKRI_BOT_TOKEN }}
         update-command: "'cargo update && cargo test'"


### PR DESCRIPTION
Switch to v1.2 with commit signoff support. This should pass DCO requirements.

closes #412 
