### PR TITLE
Fix logs command in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -24,7 +24,7 @@ Steps to reproduce the behavior:
 A clear and concise description of what you expected to happen.
 
 **Logs (please share snips of applicable logs)**
- - To get the logs of any pod, run `kubectl get logs <pod name>`
+ - To get the logs of any pod, run `kubectl logs <pod name>`
  - To get the logs of a pod that has already terminated, `kubectl get logs <pod name> --previous`
  - If you believe that the problem is with the Kubelet, run `journalctl -u kubelet` or `journalctl -u snap.microk8s.daemon-kubelet` if you are using a MicroK8s cluster.
 


### PR DESCRIPTION
<!--  Thank you for contributing to the Akri repo! Before submitting this PR, please make sure:
1. Read the Contributing Guide before submitting your PR: https://docs.akri.sh/community/contributing
2. Decide whether you need to add any labels to your PR, such as `same version` if the version should not be changed and your change will trigger the version check workflow. This will cause the workflow to automatically succeed: https://github.com/project-akri/akri/blob/main/.github/workflows/check-versioning.yml
3. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context. -->
Fixes nit in issues template to properly get logs with kubectl