### PR TITLE
Fix Kubernetes setup in end-to-end tests

### DIFF
--- a/.github/workflows/run-test-cases.yml
+++ b/.github/workflows/run-test-cases.yml
@@ -233,6 +233,7 @@ jobs:
           sudo mkdir -p $HOME/.kube
           sudo cp -i /etc/kubernetes/admin.conf $HOME/.kube/config
           sudo chown $(id -u):$(id -g) $HOME/.kube/config
+          kubectl apply -f https://raw.githubusercontent.com/coreos/flannel/master/Documentation/kube-flannel.yml
           kubectl taint nodes --all node-role.kubernetes.io/master-
           echo '--set kubernetesDistro=k8s' > /tmp/k8s_distro_to_test.txt
           echo 'kubectl' > /tmp/runtime_cmd_to_test.txt

--- a/.github/workflows/run-test-cases.yml
+++ b/.github/workflows/run-test-cases.yml
@@ -238,7 +238,7 @@ jobs:
           echo '--set kubernetesDistro=k8s' > /tmp/k8s_distro_to_test.txt
           echo 'kubectl' > /tmp/runtime_cmd_to_test.txt
           echo '~/.kube/config' > /tmp/kubeconfig_path_to_test.txt
-          until kubectl get node ${HOSTNAME,,} -o jsonpath='{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status}' | grep 'Ready=True'; do echo "waiting for kubernetes to become ready" && kubectl describe node ${HOSTNAME,,}; sleep 10; done
+          until kubectl get node ${HOSTNAME,,} -o jsonpath='{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status}' | grep 'Ready=True'; do echo "waiting for kubernetes to become ready"; sleep 10; done
 
       - if: (startsWith(github.event_name, 'pull_request')) && (startsWith(matrix.kube.runtime, 'Kubernetes'))
         name: Import local agent and controller to Kubernetes

--- a/.github/workflows/run-test-cases.yml
+++ b/.github/workflows/run-test-cases.yml
@@ -229,7 +229,7 @@ jobs:
           kubeadm version && echo "kubeadm return code: $?" || echo "kubeadm return code: $?"
           kubelet --version && echo "kubelet return code: $?" || echo "kubelet return code: $?"
           sudo swapoff -a              
-          sudo kubeadm init
+          sudo kubeadm init --pod-network-cidr=10.244.0.0/16
           sudo mkdir -p $HOME/.kube
           sudo cp -i /etc/kubernetes/admin.conf $HOME/.kube/config
           sudo chown $(id -u):$(id -g) $HOME/.kube/config

--- a/.github/workflows/run-test-cases.yml
+++ b/.github/workflows/run-test-cases.yml
@@ -233,7 +233,7 @@ jobs:
           sudo mkdir -p $HOME/.kube
           sudo cp -i /etc/kubernetes/admin.conf $HOME/.kube/config
           sudo chown $(id -u):$(id -g) $HOME/.kube/config
-          kubectl taint nodes --all node-role.kubernetes.io/master-
+          kubectl taint nodes --all node-role.kubernetes.io/control-plane- node-role.kubernetes.io/master-
           echo '--set kubernetesDistro=k8s' > /tmp/k8s_distro_to_test.txt
           echo 'kubectl' > /tmp/runtime_cmd_to_test.txt
           echo '~/.kube/config' > /tmp/kubeconfig_path_to_test.txt

--- a/.github/workflows/run-test-cases.yml
+++ b/.github/workflows/run-test-cases.yml
@@ -233,11 +233,11 @@ jobs:
           sudo mkdir -p $HOME/.kube
           sudo cp -i /etc/kubernetes/admin.conf $HOME/.kube/config
           sudo chown $(id -u):$(id -g) $HOME/.kube/config
-          kubectl taint nodes --all node-role.kubernetes.io/control-plane- node-role.kubernetes.io/master-
+          kubectl taint nodes --all node-role.kubernetes.io/master-
           echo '--set kubernetesDistro=k8s' > /tmp/k8s_distro_to_test.txt
           echo 'kubectl' > /tmp/runtime_cmd_to_test.txt
           echo '~/.kube/config' > /tmp/kubeconfig_path_to_test.txt
-          until kubectl get node ${HOSTNAME,,} -o jsonpath='{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status}' | grep 'Ready=True'; do echo "waiting for kubernetes to become ready"; sleep 10; done
+          until kubectl get node ${HOSTNAME,,} -o jsonpath='{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status}' | grep 'Ready=True'; do echo "waiting for kubernetes to become ready" && kubectl describe node ${HOSTNAME,,}; sleep 10; done
 
       - if: (startsWith(github.event_name, 'pull_request')) && (startsWith(matrix.kube.runtime, 'Kubernetes'))
         name: Import local agent and controller to Kubernetes

--- a/test/run-end-to-end.py
+++ b/test/run-end-to-end.py
@@ -93,6 +93,7 @@ def do_test():
     if not shared_test_code.check_akri_state(1, 1, 2, 2, 1, 2):
         print("Akri not running in expected state")
         os.system('sudo {} get pods,services,akric,akrii --show-labels'.format(kubectl_cmd))
+        os.system('sudo {} describe pod'.format(kubectl_cmd))
         return False
     
     #
@@ -105,6 +106,7 @@ def do_test():
     if not shared_test_code.check_akri_state(1, 1, 0, 0, 0, 0):
         print("Akri not running in expected state after taking device offline")
         os.system('sudo {} get pods,services,akric,akrii --show-labels'.format(kubectl_cmd))
+        os.system('sudo {} describe pod'.format(kubectl_cmd))
         return False
 
     # Do back online scenario
@@ -115,6 +117,7 @@ def do_test():
     if not shared_test_code.check_akri_state(1, 1, 2, 2, 1, 2):
         print("Akri not running in expected state after bringing device back online")
         os.system('sudo {} get pods,services,akric,akrii --show-labels'.format(kubectl_cmd))
+        os.system('sudo {} describe pod'.format(kubectl_cmd))
         return False
 
     #
@@ -146,6 +149,7 @@ def do_test():
     if len(brokers_info) != 2:
         print("Expected to find 2 broker pods but found: {}", len(brokers_info))
         os.system('sudo {} get pods,services,akric,akrii --show-labels'.format(kubectl_cmd))
+        os.system('sudo {} describe pod'.format(kubectl_cmd))
         return False
 
     # There is a possible race condition here between when the `kubectl delete pod` returns,
@@ -164,12 +168,14 @@ def do_test():
     if not shared_test_code.check_broker_pods_state(v1, 2):
         print("Akri not running in expected state after broker pod restoration should have happened")
         os.system('sudo {} get pods,services,akric,akrii --show-labels'.format(kubectl_cmd))
+        os.system('sudo {} describe pod'.format(kubectl_cmd))
         return False
 
     restored_brokers_info = shared_test_code.get_running_pod_names_and_uids(broker_pod_selector)
     if len(restored_brokers_info) != 2:
         print("Expected to find 2 broker pods but found: {}", len(restored_brokers_info))
         os.system('sudo {} get pods,services,akric,akrii --show-labels'.format(kubectl_cmd))
+        os.system('sudo {} describe pod'.format(kubectl_cmd))
         return False
 
     # Make sure that the deleted broker uid is different from the restored broker pod uid ... signifying
@@ -178,6 +184,7 @@ def do_test():
     if brokers_info[broker_pod_name] == restored_brokers_info[broker_pod_name]:
         print("Restored broker pod uid [{}] should differ from original broker pod uid [{}]".format(brokers_info[broker_pod_name], restored_brokers_info[broker_pod_name]))
         os.system('sudo {} get pods,services,akric,akrii --show-labels'.format(kubectl_cmd))
+        os.system('sudo {} describe pod'.format(kubectl_cmd))
         return False
 
     # Do cleanup scenario
@@ -188,6 +195,7 @@ def do_test():
     if not shared_test_code.check_akri_state(1, 1, 0, 0, 0, 0):
         print("Akri not running in expected state after deleting configuration")
         os.system('sudo {} get pods,services,akric,akrii --show-labels'.format(kubectl_cmd))
+        os.system('sudo {} describe pod'.format(kubectl_cmd))
         return False
 
     return True    


### PR DESCRIPTION
Signed-off-by: Kate Goldenring <kate.goldenring@microsoft.com>

<!--  Thank you for contributing to the Akri repo! Before submitting this PR, please make sure:
1. Read the Contributing Guide before submitting your PR: https://docs.akri.sh/community/contributing
2. Decide whether you need to add any labels to your PR, such as `same version` if the version should not be changed and your change will trigger the version check workflow. This will cause the workflow to automatically succeed: https://github.com/project-akri/akri/blob/main/.github/workflows/check-versioning.yml
3. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context. -->

**What this PR does / why we need it**:
For some reason, in the past we have not needed to install a networking addon (flannel calico etc) during Kubernetes setup in our e2e tests. Now, the node is getting stuck in a `NotReady` state, making our e2e tests fail before they can even be run. Seems like adding flannel solves the issue [a netowrking addon is needed to start coredns](https://v1-20.docs.kubernetes.io/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm/#pod-network).

closes #481 