### PR TITLE
A workflow to auto bump versions

### DIFF
--- a/.github/workflows/update-versions.yml
+++ b/.github/workflows/update-versions.yml
@@ -2,7 +2,7 @@ name: Auto Bump Versions
 
 on:
   issue_comment:                                     
-    types: [created, edited, deleted]
+    types: [created, edited]
 
 jobs:
   build:

--- a/.github/workflows/update-versions.yml
+++ b/.github/workflows/update-versions.yml
@@ -1,0 +1,62 @@
+name: Auto Bump Versions
+
+on:
+  issue_comment:                                     
+    types: [created, edited, deleted]
+
+jobs:
+  build:
+    if: ${{ github.event.issue.pull_request }}
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Checkout PR on which comment was made
+      run: hub pr checkout ${{ github.event.issue.number }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    
+    - name: Update version minor
+      if: contains(github.event.comment.body, '/version minor')
+      run: |
+        ./version.sh -u -n
+        echo "BUMP_TYPE=minor" >> $GITHUB_ENV
+
+    - name: Update version major
+      if: contains(github.event.comment.body, '/version major')
+      run: |
+        ./version.sh -u -m
+        echo "BUMP_TYPE=major" >> $GITHUB_ENV
+
+    - name: Update version patch
+      if: contains(github.event.comment.body, '/version patch')
+      run: |
+        ./version.sh -u -p
+        echo "BUMP_TYPE=patch" >> $GITHUB_ENV
+    
+    - name: Add labels
+      uses: actions/github-script@v6
+      if: ${{ env.BUMP_TYPE }}
+      with:
+        script: |
+          github.rest.issues.addLabels({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            labels: ['version/${{ env.BUMP_TYPE }}']
+          })
+
+    - name: Push Changes
+      if: ${{ env.BUMP_TYPE }}
+      run: |
+        git config user.name 'github-actions[bot]'
+        git config user.email 'github-actions[bot]@users.noreply.github.com'
+        git pull
+        git add .
+        git commit -m "Update ${{ env.BUMP_TYPE }} version" --signoff
+        git push
+    

--- a/.github/workflows/update-versions.yml
+++ b/.github/workflows/update-versions.yml
@@ -7,18 +7,32 @@ on:
 jobs:
   build:
     if: ${{ github.event.issue.pull_request }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v2
+    - name: Get PR details
+      uses: actions/github-script@v3
+      id: get-pr
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          const request = {
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            pull_number: context.issue.number
+          }
+          core.info(`Getting PR #${request.pull_number} from ${request.owner}/${request.repo}`)
+          try {
+            const result = await github.pulls.get(request)
+            return result.data
+          } catch (err) {
+            core.setFailed(`Request failed with error ${err}`)
+          }
 
-    - name: Checkout PR on which comment was made
-      run: hub pr checkout ${{ github.event.issue.number }}
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Checkout PR
+      uses: actions/checkout@v3
+      with:
+        repository: ${{ fromJSON(steps.get-pr.outputs.result).head.repo.full_name }}
+        ref: ${{ fromJSON(steps.get-pr.outputs.result).head.ref }}
     
     - name: Update version minor
       if: contains(github.event.comment.body, '/version minor')
@@ -59,4 +73,4 @@ jobs:
         git add .
         git commit -m "Update ${{ env.BUMP_TYPE }} version" --signoff
         git push
-    
+        


### PR DESCRIPTION
**What this PR does / why we need it**:

Updating versions on behalf of the contributor since we already have a run that checks the version would be very helpful as discussed in yesterday's meeting and in #500 . With this PR being merged we should expect the contributing workflow to look like this:

- Contributor makes a PR not necessarily running the `version.sh` file themselves
- Reviewer decides if it needs to be a patch, minor or major
- Reviewer comments one of of the following the PR (these comments have no effects if made on an issue):
    - /version major
    - /version minor
    - /version patch
- GitHub Actions makes the required changes and adds a commit to the same PR 
- GitHub Actions adds the appropriate label, one of:
   - version/major
   - version/minor
   - version/patch 

**Special notes for your reviewer**:

Before merging this PR we need to create labels: `version/minor`, `version/major` and `version/patch`

Closes #500 

**If applicable**:
- [ ] this PR has an associated PR with documentation in [akri-docs](https://github.com/project-akri/akri-docs) (WIP, this also requires changes to some documentation in this repo which are made in #511)
- [ ] this PR contains unit tests
- [x] added code adheres to standard Rust formatting (`cargo fmt`)
- [x] code builds properly (`cargo build`)
- [x] code is free of common mistakes (`cargo clippy`)
- [x] all Akri tests succeed (`cargo test`)
- [x] inline documentation builds (`cargo doc`)
- [x] version has been updated appropriately (`./version.sh`)
- [x] all commits pass the [DCO bot check](https://probot.github.io/apps/dco/) by being signed off -- see the failing DCO check for instructions on how to retroactively sign commits