### PR TITLE
Update PR template in accordance to new workflow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,5 +15,4 @@
 - [ ] code is free of common mistakes (`cargo clippy`)
 - [ ] all Akri tests succeed (`cargo test`)
 - [ ] inline documentation builds (`cargo doc`)
-- [ ] version has been updated appropriately (`./version.sh`)
 - [ ] all commits pass the [DCO bot check](https://probot.github.io/apps/dco/) by being signed off -- see the failing DCO check for instructions on how to retroactively sign commits


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR follows #510 which proposes introducing a new workflow for auto bumping the versions. This PR removes running `./version.sh` form the PR template which I think there is no need for now, what do you think?

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR has an associated PR with documentation in [akri-docs](https://github.com/project-akri/akri-docs)
- [ ] this PR contains unit tests
- [x] added code adheres to standard Rust formatting (`cargo fmt`)
- [x] code builds properly (`cargo build`)
- [x] code is free of common mistakes (`cargo clippy`)
- [x] all Akri tests succeed (`cargo test`)
- [x] inline documentation builds (`cargo doc`)
- [ ] version has been updated appropriately (`./version.sh`)
- [x] all commits pass the [DCO bot check](https://probot.github.io/apps/dco/) by being signed off -- see the failing DCO check for instructions on how to retroactively sign commits