### PR TITLE
Fix double resources declaration in HELM values

### DIFF
--- a/deployment/helm/values.yaml
+++ b/deployment/helm/values.yaml
@@ -796,17 +796,6 @@ udev:
       tag:
       # pullPolicy is the pull policy
       pullPolicy: ""
-    resources:
-      # memoryRequest defines the minimum amount of RAM that must be available to this Pod
-      # for it to be scheduled by the Kubernetes Scheduler
-      memoryRequest: 11Mi
-      # cpuRequest defines the minimum amount of CPU that must be available to this Pod
-      # for it to be scheduled by the Kubernetes Scheduler
-      cpuRequest: 10m
-      # memoryLimit defines the maximum amount of RAM this Pod can consume.
-      memoryLimit: 24Mi
-      # cpuLimit defines the maximum amount of CPU this Pod can consume.
-      cpuLimit: 23m
     # useNetworkConnection specifies whether the discovery handler should make a networked connection
     # with Agents, using its pod IP address when registering
     useNetworkConnection: false


### PR DESCRIPTION
**What this PR does / why we need it**:
The `values.yaml` for HELM Chart is invalid as the "resources" block for udev discovery is duplicated.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR has an associated PR with documentation in [akri-docs](https://github.com/project-akri/akri-docs)
- [ ] this PR contains unit tests
- [ ] added code adheres to standard Rust formatting (`cargo fmt`)
- [ ] code builds properly (`cargo build`)
- [ ] code is free of common mistakes (`cargo clippy`)
- [ ] all Akri tests succeed (`cargo test`)
- [ ] inline documentation builds (`cargo doc`)
- [x] all commits pass the [DCO bot check](https://probot.github.io/apps/dco/) by being signed off -- see the failing DCO check for instructions on how to retroactively sign commits