### PR TITLE
Increase tests workflow timeout

### DIFF
--- a/.github/workflows/run-test-cases.yml
+++ b/.github/workflows/run-test-cases.yml
@@ -116,7 +116,7 @@ jobs:
           - runtime: K3s-1.22
             version: v1.22.6+k3s1
           - runtime: K3s-1.23
-            version: v1.23.12+k3s1
+            version: v1.23.13+k3s1
           - runtime: K3s-1.24
             version: v1.24.6+k3s1
           - runtime: K3s-1.25

--- a/.github/workflows/run-test-cases.yml
+++ b/.github/workflows/run-test-cases.yml
@@ -97,7 +97,7 @@ jobs:
   test-cases:
     needs: build-containers
     runs-on: ubuntu-18.04
-    timeout-minutes: 60
+    timeout-minutes: 90
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
<!--  Thank you for contributing to the Akri repo! Before submitting this PR, please make sure:
1. Read the Contributing Guide before submitting your PR: https://docs.akri.sh/community/contributing
2. Decide whether you need to add any labels to your PR, such as `same version` if the version should not be changed and your change will trigger the version check workflow. This will cause the workflow to automatically succeed: https://github.com/project-akri/akri/blob/main/.github/workflows/check-versioning.yml
3. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context. -->

**What this PR does / why we need it**:
fixes #531 (maybe) by increasing the timeout. We should look into how to shorten the tests and why the K3s tests in particular fail moreso than the K8s or MicroK8s given that they seem to have similar test runtimes.

Also bumps k3s 1.23 version to latest.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR has an associated PR with documentation in [akri-docs](https://github.com/project-akri/akri-docs)
- [ ] this PR contains unit tests
- [ ] added code adheres to standard Rust formatting (`cargo fmt`)
- [ ] code builds properly (`cargo build`)
- [ ] code is free of common mistakes (`cargo clippy`)
- [ ] all Akri tests succeed (`cargo test`)
- [ ] inline documentation builds (`cargo doc`)
- [ ] all commits pass the [DCO bot check](https://probot.github.io/apps/dco/) by being signed off -- see the failing DCO check for instructions on how to retroactively sign commits