### PR TITLE
Add new K8S versions to tests

### DIFF
--- a/.github/workflows/run-test-cases.yml
+++ b/.github/workflows/run-test-cases.yml
@@ -111,26 +111,34 @@ jobs:
             version: 1.23/stable
           - runtime: MicroK8s-1.24
             version: 1.24/stable
+          - runtime: MicroK8s-1.25
+            version: 1.25/stable
+          - runtime: MicroK8s-1.26
+            version: 1.26/stable
           - runtime: K3s-1.21
-            version: v1.21.5+k3s1
+            version: v1.21.14+k3s1
           - runtime: K3s-1.22
-            version: v1.22.6+k3s1
+            version: v1.22.16+k3s1
           - runtime: K3s-1.23
-            version: v1.23.13+k3s1
+            version: v1.23.14+k3s1
           - runtime: K3s-1.24
-            version: v1.24.6+k3s1
+            version: v1.24.8+k3s1
           - runtime: K3s-1.25
-            version: v1.25.2+k3s1
+            version: v1.25.4+k3s1
+          - runtime: K3s-1.26
+            version: v1.26.0-rc2+k3s1
           - runtime: Kubernetes-1.21
             version: 1.21.14-00
           - runtime: Kubernetes-1.22
-            version: 1.22.14-00
+            version: 1.22.17-00
           - runtime: Kubernetes-1.23
-            version: 1.23.11-00
+            version: 1.23.15-00
           - runtime: Kubernetes-1.24
-            version: 1.24.5-00
+            version: 1.24.9-00
           - runtime: Kubernetes-1.25
-            version: 1.25.1-00
+            version: 1.25.5-00
+          - runtime: Kubernetes-1.26
+            version: 1.26.0-00
         test:
           - case: end-to-end
             file: test/run-end-to-end.py
@@ -177,7 +185,7 @@ jobs:
           sudo chmod +x install.sh
           ./install.sh server --kubelet-arg=eviction-hard="imagefs.available<1%,nodefs.available<1%" --kubelet-arg=eviction-minimum-reclaim="imagefs.available=1%,nodefs.available=1%"
           sudo addgroup k3s-admin
-          sudo adduser $USER k3s-admin
+          sudo adduser $USER k3s-admin  
           sudo usermod -a -G k3s-admin $USER
           sudo chgrp k3s-admin /etc/rancher/k3s/k3s.yaml
           sudo chmod g+r /etc/rancher/k3s/k3s.yaml
@@ -209,8 +217,10 @@ jobs:
           sudo apt-get install -y apt-transport-https ca-certificates curl
           sudo curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
           echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+          sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker.gpg
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list
           sudo apt-get update
-          sudo apt-get install -o Dpkg::Options::="--force-overwrite" -y --allow-downgrades kubelet=${{ matrix.kube.version }} kubeadm=${{ matrix.kube.version }} kubectl=${{ matrix.kube.version }} 
+          sudo apt-get install -o Dpkg::Options::="--force-overwrite" -y --allow-downgrades kubelet=${{ matrix.kube.version }} kubeadm=${{ matrix.kube.version }} kubectl=${{ matrix.kube.version }} containerd.io
           kubectl version && echo "kubectl return code: $?" || echo "kubectl return code: $?"
           kubeadm version && echo "kubeadm return code: $?" || echo "kubeadm return code: $?"
           kubelet --version && echo "kubelet return code: $?" || echo "kubelet return code: $?"
@@ -236,16 +246,16 @@ jobs:
           sudo chown $(id -u):$(id -g) $HOME/.kube/config
           kubectl apply -f https://raw.githubusercontent.com/coreos/flannel/master/Documentation/kube-flannel.yml
 
-          # Kubernetes 1.25+ replaces the master label with control plane
-          if [ "${{ matrix.kube.version }}" == "1.25.1-00" ]; then
-            kubectl taint nodes --all node-role.kubernetes.io/control-plane-
-          else
-            kubectl taint nodes --all node-role.kubernetes.io/master-
-          fi
 
-          # Kubernetes 1.24 has both labels applicable, to be safe tainting both labels
-          if [ "${{ matrix.kube.version }}" == "1.24.5-00" ]; then
+          verlte() { [  "$1" = "`echo -e "$1\n$2" | sort -V | head -n1`" ] ; }
+          verlt()  { [ "$1" = "$2" ] && return 1 || verlte $1 $2 ; }
+          # Kubernetes 1.24+ has control plane label
+          if verlte "1.24.0" "${{ matrix.kube.version }}" ; then
             kubectl taint nodes --all node-role.kubernetes.io/control-plane-
+          fi
+          # Kubernetes before 1.25 has master label
+          if verlt "${{ matrix.kube.version }}" "1.25.0" ; then
+            kubectl taint nodes --all node-role.kubernetes.io/master-
           fi
 
           echo '--set kubernetesDistro=k8s' > /tmp/k8s_distro_to_test.txt
@@ -291,7 +301,7 @@ jobs:
           sudo cat ~/.kube/config
           sudo microk8s.enable rbac dns
           sudo sed -i 's/memory.available<100Mi,nodefs.available<1Gi,imagefs.available<1Gi/memory.available<25Mi,nodefs.available<50Mi,imagefs.available<50Mi/' /var/snap/microk8s/current/args/kubelet
-          sudo systemctl restart snap.microk8s.daemon-kubelet
+          sudo systemctl restart snap.microk8s.daemon-kubelite
           until sudo microk8s.status --wait-ready; do sleep 5s; echo "Try again"; done
           echo '--set kubernetesDistro=microk8s' > /tmp/k8s_distro_to_test.txt
           echo 'microk8s kubectl' > /tmp/runtime_cmd_to_test.txt

--- a/.github/workflows/run-test-cases.yml
+++ b/.github/workflows/run-test-cases.yml
@@ -118,15 +118,15 @@ jobs:
           - runtime: K3s-1.21
             version: v1.21.14+k3s1
           - runtime: K3s-1.22
-            version: v1.22.16+k3s1
+            version: v1.22.17+k3s1
           - runtime: K3s-1.23
-            version: v1.23.14+k3s1
+            version: v1.23.15+k3s1
           - runtime: K3s-1.24
-            version: v1.24.8+k3s1
+            version: v1.24.9+k3s1
           - runtime: K3s-1.25
-            version: v1.25.4+k3s1
+            version: v1.25.5+k3s1
           - runtime: K3s-1.26
-            version: v1.26.0-rc2+k3s1
+            version: v1.26.0+k3s1
           - runtime: Kubernetes-1.21
             version: 1.21.14-00
           - runtime: Kubernetes-1.22
@@ -276,11 +276,7 @@ jobs:
       - if: (startsWith(github.event_name, 'pull_request')) && (startsWith(matrix.kube.runtime, 'Kubernetes'))
         name: Import local agent and controller to Kubernetes
         run: |
-          sudo docker load --input agent.tar
-          sudo docker load --input controller.tar
-          sudo docker load --input webhook-configuration.tar
-          sudo docker image ls
-          # No longer are using docker for container runtime, need to load to containerd with ctr
+          # Need to load to containerd with ctr
           # -n allows kubernetes to see the image
           sudo ctr -n=k8s.io image import agent.tar
           sudo ctr -n=k8s.io image import controller.tar

--- a/.github/workflows/run-test-cases.yml
+++ b/.github/workflows/run-test-cases.yml
@@ -103,10 +103,6 @@ jobs:
       fail-fast: false
       matrix:
         kube:
-          - runtime: MicroK8s-1.21
-            version: 1.21/stable
-          - runtime: MicroK8s-1.22
-            version: 1.22/stable
           - runtime: MicroK8s-1.23
             version: 1.23/stable
           - runtime: MicroK8s-1.24
@@ -115,10 +111,6 @@ jobs:
             version: 1.25/stable
           - runtime: MicroK8s-1.26
             version: 1.26/stable
-          - runtime: K3s-1.21
-            version: v1.21.14+k3s1
-          - runtime: K3s-1.22
-            version: v1.22.17+k3s1
           - runtime: K3s-1.23
             version: v1.23.15+k3s1
           - runtime: K3s-1.24
@@ -127,10 +119,6 @@ jobs:
             version: v1.25.5+k3s1
           - runtime: K3s-1.26
             version: v1.26.0+k3s1
-          - runtime: Kubernetes-1.21
-            version: 1.21.14-00
-          - runtime: Kubernetes-1.22
-            version: 1.22.17-00
           - runtime: Kubernetes-1.23
             version: 1.23.15-00
           - runtime: Kubernetes-1.24


### PR DESCRIPTION
**What this PR does / why we need it**:
Kubernetes released new upstream version (1.26) and all distros were updated to take it into account.
This PR also updates the previous minor versions where applicable.

**Special notes for your reviewer**:
I've updated also a few things:
- In 1.26 containerd must be updated as [CRI v1alpha2 was removed](https://kubernetes.io/blog/2022/12/09/kubernetes-v1-26-release/#cri-v1alpha2-removed).
- Logic for node taints was changed to take into account all next versions of Kubernetes (was quite static in current implementation)

**If applicable**:
- [ ] this PR has an associated PR with documentation in [akri-docs](https://github.com/project-akri/akri-docs)
- [ ] this PR contains unit tests
- [ ] added code adheres to standard Rust formatting (`cargo fmt`)
- [ ] code builds properly (`cargo build`)
- [ ] code is free of common mistakes (`cargo clippy`)
- [ ] all Akri tests succeed (`cargo test`)
- [ ] inline documentation builds (`cargo doc`)
- [ ] all commits pass the [DCO bot check](https://probot.github.io/apps/dco/) by being signed off -- see the failing DCO check for instructions on how to retroactively sign commits