### PR TITLE
Update nodejs actions to node16

### DIFF
--- a/.github/actions/build-component-multi-arch/action.yml
+++ b/.github/actions/build-component-multi-arch/action.yml
@@ -23,5 +23,5 @@ inputs:
     description: Specify the github event name (push, pull_request, release, etc)
     required: true
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'main.js'

--- a/.github/actions/build-component-per-arch/action.yml
+++ b/.github/actions/build-component-per-arch/action.yml
@@ -38,5 +38,5 @@ inputs:
     description: Specify whether a PR has been merged
     required: true
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'main.js'

--- a/.github/actions/build-intermediate/action.yml
+++ b/.github/actions/build-intermediate/action.yml
@@ -35,5 +35,5 @@ inputs:
     description: Specify whether a PR has been merged
     required: true
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'main.js'

--- a/.github/workflows/auto-update-dependencies.yml
+++ b/.github/workflows/auto-update-dependencies.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
     - name: Checkout the head commit of the branch
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         persist-credentials: false 
         

--- a/.github/workflows/build-agent-container.yml
+++ b/.github/workflows/build-agent-container.yml
@@ -27,12 +27,12 @@ jobs:
 
     steps:
     - name: Checkout the head commit of the branch
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         persist-credentials: false
 
     - name: Prepare To Install
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: 12
     - name: Install Deps
@@ -80,12 +80,12 @@ jobs:
 
     steps:
     - name: Checkout repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         persist-credentials: false
 
     - name: Prepare To Install
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: 12
     - name: Install Deps

--- a/.github/workflows/build-anomaly-detection-app-container.yml
+++ b/.github/workflows/build-anomaly-detection-app-container.yml
@@ -47,12 +47,12 @@ jobs:
 
     steps:
     - name: Checkout the head commit of the branch
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         persist-credentials: false
 
     - name: Prepare To Install
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: 12
     - name: Install Deps
@@ -84,10 +84,10 @@ jobs:
 
     steps:
     - name: Checkout repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Prepare To Install
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: 12
     - name: Install Deps

--- a/.github/workflows/build-controller-container.yml
+++ b/.github/workflows/build-controller-container.yml
@@ -27,12 +27,12 @@ jobs:
           - amd64
     steps:
     - name: Checkout the head commit of the branch
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         persist-credentials: false
 
     - name: Prepare To Install
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: 12
     - name: Install Deps
@@ -75,12 +75,12 @@ jobs:
 
     steps:
     - name: Checkout repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         persist-credentials: false
 
     - name: Prepare To Install
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: 12
     - name: Install Deps

--- a/.github/workflows/build-discovery-handlers.yml
+++ b/.github/workflows/build-discovery-handlers.yml
@@ -29,12 +29,12 @@ jobs:
 
     steps:
     - name: Checkout the head commit of the branch
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         persist-credentials: false
 
     - name: Prepare To Install
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: 12
     - name: Install Deps
@@ -84,12 +84,12 @@ jobs:
 
     steps:
     - name: Checkout repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         persist-credentials: false
 
     - name: Prepare To Install
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: 12
     - name: Install Deps

--- a/.github/workflows/build-onvif-video-broker-container.yml
+++ b/.github/workflows/build-onvif-video-broker-container.yml
@@ -47,12 +47,12 @@ jobs:
 
     steps:
     - name: Checkout the head commit of the branch
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         persist-credentials: false
 
     - name: Prepare To Install
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: 12
     - name: Install Deps
@@ -84,12 +84,12 @@ jobs:
 
     steps:
     - name: Checkout repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         persist-credentials: false
 
     - name: Prepare To Install
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: 12
     - name: Install Deps

--- a/.github/workflows/build-opcua-monitoring-broker-container.yml
+++ b/.github/workflows/build-opcua-monitoring-broker-container.yml
@@ -47,12 +47,12 @@ jobs:
 
     steps:
     - name: Checkout the head commit of the branch
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         persist-credentials: false
 
     - name: Prepare To Install
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: 12
     - name: Install Deps
@@ -84,10 +84,10 @@ jobs:
 
     steps:
     - name: Checkout repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Prepare To Install
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: 12
     - name: Install Deps

--- a/.github/workflows/build-opencv-base-container.yml
+++ b/.github/workflows/build-opencv-base-container.yml
@@ -32,20 +32,20 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'issue_comment' && contains(github.event.comment.body, '/add-same-version-label')
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Add same version label
-      uses: actions/github-script@0.9.0
+      uses: actions/github-script@v6
       if: success()
       with:
         github-token: ${{secrets.GITHUB_TOKEN}}
         script: |
-          github.issues.addLabels({
+          github.rest.issues.addLabels({
             issue_number: context.issue.number,
             owner: context.repo.owner,
             repo: context.repo.repo,
             labels: ['same version']
           })
-          github.issues.createComment({
+          github.rest.issues.createComment({
             issue_number: context.issue.number,
             owner: context.repo.owner,
             repo: context.repo.repo,
@@ -56,20 +56,20 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'issue_comment' && contains(github.event.comment.body, '/add-build-dependency-containers-label')
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Add build dependency containers label
-      uses: actions/github-script@0.9.0
+      uses: actions/github-script@v6
       if: success()
       with:
         github-token: ${{secrets.GITHUB_TOKEN}}
         script: |
-          github.issues.addLabels({
+          github.rest.issues.addLabels({
             issue_number: context.issue.number,
             owner: context.repo.owner,
             repo: context.repo.repo,
             labels: ['build dependency containers']
           })
-          github.issues.createComment({
+          github.rest.issues.createComment({
             issue_number: context.issue.number,
             owner: context.repo.owner,
             repo: context.repo.repo,
@@ -80,14 +80,14 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request' && (github.event.action == 'opened') && !contains(github.event.pull_request.labels.*.name, 'build dependency containers')
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Add comment about missing build dependency containers label
-      uses: actions/github-script@0.9.0
+      uses: actions/github-script@v6
       if: success()
       with:
         github-token: ${{secrets.GITHUB_TOKEN}}
         script: |
-          github.issues.createComment({
+          github.rest.issues.createComment({
             issue_number: context.payload.pull_request.number,
             owner: context.repo.owner,
             repo: context.repo.repo,
@@ -105,7 +105,7 @@ jobs:
           - amd64
     steps:
     - name: Checkout the head commit of the branch
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         persist-credentials: false
 
@@ -119,7 +119,7 @@ jobs:
         git diff origin/main -- ./build/intermediate-containers.mk | grep "BUILD_OPENCV_BASE_VERSION = " | wc -l | grep -v 0
 
     - name: Prepare To Install
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: 12
     - name: Install Deps

--- a/.github/workflows/build-rust-code.yml
+++ b/.github/workflows/build-rust-code.yml
@@ -67,7 +67,7 @@ jobs:
     
     steps:
     - name: Checkout the head commit of the branch
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         persist-credentials: false
 
@@ -95,7 +95,7 @@ jobs:
         tar -cvf /tmp/rust-${{ matrix.arch.label }}-binaries.tar `cat $tar_manifest`
 
     - name: Upload target binaries as artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: rust-${{ matrix.arch.label }}-binaries
         path: /tmp/rust-${{ matrix.arch.label }}-binaries.tar

--- a/.github/workflows/build-rust-crossbuild-container.yml
+++ b/.github/workflows/build-rust-crossbuild-container.yml
@@ -32,20 +32,20 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'issue_comment' && contains(github.event.comment.body, '/add-same-version-label')
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Add same version label
-      uses: actions/github-script@0.9.0
+      uses: actions/github-script@v6
       if: success()
       with:
         github-token: ${{secrets.GITHUB_TOKEN}}
         script: |
-          github.issues.addLabels({
+          github.rest.issues.addLabels({
             issue_number: context.issue.number,
             owner: context.repo.owner,
             repo: context.repo.repo,
             labels: ['same version']
           })
-          github.issues.createComment({
+          github.rest.issues.createComment({
             issue_number: context.issue.number,
             owner: context.repo.owner,
             repo: context.repo.repo,
@@ -56,20 +56,20 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'issue_comment' && contains(github.event.comment.body, '/add-build-dependency-containers-label')
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Add build dependency containers label
-      uses: actions/github-script@0.9.0
+      uses: actions/github-script@v6
       if: success()
       with:
         github-token: ${{secrets.GITHUB_TOKEN}}
         script: |
-          github.issues.addLabels({
+          github.rest.issues.addLabels({
             issue_number: context.issue.number,
             owner: context.repo.owner,
             repo: context.repo.repo,
             labels: ['build dependency containers']
           })
-          github.issues.createComment({
+          github.rest.issues.createComment({
             issue_number: context.issue.number,
             owner: context.repo.owner,
             repo: context.repo.repo,
@@ -80,14 +80,14 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request' && (github.event.action == 'opened') && !contains(github.event.pull_request.labels.*.name, 'build dependency containers')
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Add comment about missing build dependency containers label
-      uses: actions/github-script@0.9.0
+      uses: actions/github-script@v6
       if: success()
       with:
         github-token: ${{secrets.GITHUB_TOKEN}}
         script: |
-          github.issues.createComment({
+          github.rest.issues.createComment({
             issue_number: context.payload.pull_request.number,
             owner: context.repo.owner,
             repo: context.repo.repo,
@@ -105,7 +105,7 @@ jobs:
           - amd64
     steps:
     - name: Checkout the head commit of the branch
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         persist-credentials: false
 
@@ -119,7 +119,7 @@ jobs:
         git diff origin/main -- ./build/intermediate-containers.mk | grep "BUILD_RUST_CROSSBUILD_VERSION = " | wc -l | grep -v 0
 
     - name: Prepare To Install
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: 12
     - name: Install Deps

--- a/.github/workflows/build-udev-video-broker-container.yml
+++ b/.github/workflows/build-udev-video-broker-container.yml
@@ -28,12 +28,12 @@ jobs:
 
     steps:
     - name: Checkout the head commit of the branch
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         persist-credentials: false
 
     - name: Prepare To Install
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: 12
     - name: Install Deps
@@ -76,12 +76,12 @@ jobs:
 
     steps:
     - name: Checkout repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         persist-credentials: false
 
     - name: Prepare To Install
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: 12
     - name: Install Deps

--- a/.github/workflows/build-video-streaming-app-container.yml
+++ b/.github/workflows/build-video-streaming-app-container.yml
@@ -47,12 +47,12 @@ jobs:
 
     steps:
     - name: Checkout the head commit of the branch
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         persist-credentials: false
 
     - name: Prepare To Install
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: 12
     - name: Install Deps
@@ -84,12 +84,12 @@ jobs:
 
     steps:
     - name: Checkout repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         persist-credentials: false
 
     - name: Prepare To Install
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: 12
     - name: Install Deps

--- a/.github/workflows/build-webhook-configuration-container.yml
+++ b/.github/workflows/build-webhook-configuration-container.yml
@@ -27,12 +27,12 @@ jobs:
 
     steps:
       - name: Checkout the head commit of the branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           persist-credentials: false
 
       - name: Prepare To Install
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: 12
       - name: Install Deps
@@ -75,10 +75,10 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Prepare To Install
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: 12
       - name: Install Deps

--- a/.github/workflows/cancel-previous-pr-workflows.yml
+++ b/.github/workflows/cancel-previous-pr-workflows.yml
@@ -9,6 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.workflow_run.event == 'pull_request'
     steps:
-    - uses: styfle/cancel-workflow-action@0.8.0
+    - uses: styfle/cancel-workflow-action@0.11.0
       with:
         workflow_id: ${{ github.event.workflow.id }}

--- a/.github/workflows/check-rust.yml
+++ b/.github/workflows/check-rust.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
     - name: Checkout the head commit of the branch
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         persist-credentials: false
 

--- a/.github/workflows/check-versioning.yml
+++ b/.github/workflows/check-versioning.yml
@@ -55,7 +55,7 @@ jobs:
 
     steps:
     - name: Checkout the head commit of the branch
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         persist-credentials: false
 

--- a/.github/workflows/run-helm.yml
+++ b/.github/workflows/run-helm.yml
@@ -27,11 +27,13 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout the head commit of the branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           persist-credentials: false
 
-      - uses: azure/setup-helm@v1
+      - uses: azure/setup-helm@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Lint helm chart
         run: |
@@ -44,11 +46,11 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout the head commit of the branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           persist-credentials: false
 
-      - uses: azure/setup-helm@v1
+      - uses: azure/setup-helm@v3
         with:
           version: "v3.4.0"
 
@@ -88,14 +90,14 @@ jobs:
 
       - name: Upload new helm package as artifact
         if: (github.event_name == 'release') || (github.event_name == 'push' && github.ref == 'refs/heads/main') || (startsWith(github.event_name, 'pull_request') && github.event.action == 'closed' && github.event.pull_request.merged == true && github.ref != 'refs/heads/main')
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: charts
           path: /tmp/helm/repo
 
       - name: Checkout gh-pages
         if: (github.event_name == 'release') || (github.event_name == 'push' && github.ref == 'refs/heads/main') || (startsWith(github.event_name, 'pull_request') && github.event.action == 'closed' && github.event.pull_request.merged == true && github.ref != 'refs/heads/main')
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: gh-pages
           persist-credentials: false
@@ -113,7 +115,7 @@ jobs:
 
       - name: Upload new merged helm chart index as artifact
         if: (github.event_name == 'release') || (github.event_name == 'push' && github.ref == 'refs/heads/main') || (startsWith(github.event_name, 'pull_request') && github.event.action == 'closed' && github.event.pull_request.merged == true && github.ref != 'refs/heads/main')
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: index
           path: index.yaml

--- a/.github/workflows/run-tarpaulin.yml
+++ b/.github/workflows/run-tarpaulin.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
     - name: Checkout the head commit of the branch
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         persist-credentials: false
 
@@ -53,14 +53,14 @@ jobs:
 
     - name: Upload report to codecov for push
       if: (!(startsWith(github.event_name, 'pull_request')))
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v3
       with:
         token: ${{secrets.CODECOV_TOKEN}}
         fail_ci_if_error: true
         verbose: true
 
     - name: Archive code coverage results
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v3
       with:
         name: code-coverage-report
         path: cobertura.xml

--- a/.github/workflows/run-test-cases.yml
+++ b/.github/workflows/run-test-cases.yml
@@ -50,7 +50,7 @@ jobs:
 
     steps:
       - name: Checkout the head commit of the branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           persist-credentials: false
 
@@ -77,19 +77,19 @@ jobs:
 
       - name: Upload Agent container as artifact
         if: startsWith(github.event_name, 'pull_request')
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: agent.tar
           path: agent.tar
       - name: Upload Controller container as artifact
         if: startsWith(github.event_name, 'pull_request')
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: controller.tar
           path: controller.tar
       - name: Upload Webhook-Configuration container as artifact
         if: startsWith(github.event_name, 'pull_request')
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: webhook-configuration.tar
           path: webhook-configuration.tar
@@ -135,12 +135,12 @@ jobs:
 
     steps:
       - name: Checkout the head commit of the branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           persist-credentials: false
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
       - name: Install Python kubernetes dependency
@@ -150,17 +150,17 @@ jobs:
 
       - name: Download Agent container artifact
         if: startsWith(github.event_name, 'pull_request')
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: agent.tar
       - name: Download Controller container artifact
         if: startsWith(github.event_name, 'pull_request')
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: controller.tar
       - name: Download Webhook-Configuration container artifact
         if: startsWith(github.event_name, 'pull_request')
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: webhook-configuration.tar
 
@@ -337,19 +337,19 @@ jobs:
 
       - name: Upload Agent log as artifact
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.kube.runtime }}-${{ matrix.test.case }}-agent-log
           path: /tmp/agent_log.txt
       - name: Upload controller log as artifact
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.kube.runtime }}-${{ matrix.test.case }}-controller-log
           path: /tmp/controller_log.txt
       - name: Upload webhook log as artifact
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.kube.runtime }}-${{ matrix.test.case }}-webhook-log
           path: /tmp/webhook_log.txt

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -9,7 +9,7 @@ jobs:
   security_audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Run security audit check
         id: cargo-audit
         if: github.repository == 'project-akri/akri' # only run on main repo and not forks
@@ -23,7 +23,7 @@ jobs:
       # sends an email if security audit failed 
       - name: Send mail
         if: steps.cargo-audit.outcome != 'success' && github.repository == 'project-akri/akri' # only run on main repo and not forks
-        uses: dawidd6/action-send-mail@v2
+        uses: dawidd6/action-send-mail@v3
         with:
           server_address: smtp-mail.outlook.com
           server_port: 587

--- a/.github/workflows/stale-tasks.yml
+++ b/.github/workflows/stale-tasks.yml
@@ -9,7 +9,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v4
+      - uses: actions/stale@v7
         with:
           stale-issue-label: stale
           stale-pr-label: stale

--- a/.github/workflows/update-versions.yml
+++ b/.github/workflows/update-versions.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
     - name: Get PR details
-      uses: actions/github-script@v3
+      uses: actions/github-script@v6
       id: get-pr
       with:
         script: |
@@ -22,7 +22,7 @@ jobs:
           }
           core.info(`Getting PR #${request.pull_number} from ${request.owner}/${request.repo}`)
           try {
-            const result = await github.pulls.get(request)
+            const result = await github.rest.pulls.get(request)
             return result.data
           } catch (err) {
             core.setFailed(`Request failed with error ${err}`)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates nodejs actions used by the different workflows to node16 as node12 is deprecated.
It updates both embedded actions in the projects and dependent actions (except `actions-rs` actions, see below).
It closes #537 

**Special notes for your reviewer**:
`actions-rs` actions [(`audit-check`](https://github.com/actions-rs/audit-check) and [`toolchain`)](https://github.com/actions-rs/toolchain) don't have node16 compatible versions available and the maintainer is gone. I would advise to switch to other actions. I found one for the toolchain: the [dtolnay/rust-toolchain](https://github.com/dtolnay/rust-toolchain) one but none for the audit-check. We can maybe tackle that in another PR.

**If applicable**:
- [ ] this PR has an associated PR with documentation in [akri-docs](https://github.com/project-akri/akri-docs)
- [ ] this PR contains unit tests
- [ ] added code adheres to standard Rust formatting (`cargo fmt`)
- [ ] code builds properly (`cargo build`)
- [ ] code is free of common mistakes (`cargo clippy`)
- [ ] all Akri tests succeed (`cargo test`)
- [ ] inline documentation builds (`cargo doc`)
- [x] all commits pass the [DCO bot check](https://probot.github.io/apps/dco/) by being signed off -- see the failing DCO check for instructions on how to retroactively sign commits