### PR TITLE
Specify `crictl` container runtime in e2e test workflow

### DIFF
--- a/.github/workflows/run-test-cases.yml
+++ b/.github/workflows/run-test-cases.yml
@@ -259,7 +259,7 @@ jobs:
           sudo ctr -n=k8s.io image import agent.tar
           sudo ctr -n=k8s.io image import controller.tar
           sudo ctr -n=k8s.io image import webhook-configuration.tar
-          sudo crictl images
+          sudo crictl --runtime-endpoint unix:///var/run/containerd/containerd.sock images
 
       - if: startsWith(matrix.kube.runtime, 'MicroK8s')
         name: Install MicroK8s


### PR DESCRIPTION
<!--  Thank you for contributing to the Akri repo! Before submitting this PR, please make sure:
1. Read the Contributing Guide before submitting your PR: https://docs.akri.sh/community/contributing
2. Decide whether you need to add any labels to your PR, such as `same version` if the version should not be changed and your change will trigger the version check workflow. This will cause the workflow to automatically succeed: https://github.com/project-akri/akri/blob/main/.github/workflows/check-versioning.yml
3. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context. -->

**What this PR does / why we need it**:
Currently the e2e [tests are failing](https://github.com/project-akri/akri/actions/runs/4208520783/jobs/7304830454) for K8s due to the container runtime (of `containerd`) not being specified for `crictl`. This will hopefully resolve the issue by specifying a runtime as env vars: https://kubernetes.io/docs/tasks/debug/debug-cluster/crictl/#general-usage.

```
sudo crictl images
  shell: /usr/bin/bash -e {0}
  env:
    pythonLocation: /opt/hostedtoolcache/Python/3.[8](https://github.com/project-akri/akri/actions/runs/4208520783/jobs/7304830454#step:12:8).16/x64
    LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.8.16/x64/lib
unpacking ghcr.io/project-akri/akri/agent-full:pr-amd64 (sha256:4c2cdc275ff3756d026cb4e743675a85[9](https://github.com/project-akri/akri/actions/runs/4208520783/jobs/7304830454#step:12:9)4fccf44705253585fe31cb8476eb9b4)...done
unpacking ghcr.io/project-akri/akri/controller:pr-amd64 (sha256:9963[10](https://github.com/project-akri/akri/actions/runs/4208520783/jobs/7304830454#step:12:10)3feed28bc031750bc75a6b3373f4db32c32efb5d5[11](https://github.com/project-akri/akri/actions/runs/4208520783/jobs/7304830454#step:12:11)850975e4ba2cb39)...done
unpacking ghcr.io/project-akri/akri/webhook-configuration:pr-amd64 (sha256:36de67b2f1f67f931978f159dc0fb7b8ed891749[14](https://github.com/project-akri/akri/actions/runs/4208520783/jobs/7304830454#step:12:15)310d21a693eb8bdad28a05)...done
time="2023-02-18T00:21:19Z" level=warning msg="image connect using default endpoints: [unix:///var/run/dockershim.sock unix:///run/containerd/containerd.sock unix:///run/crio/crio.sock unix:///var/run/cri-dockerd.sock]. As the default settings are now deprecated, you should set the endpoint instead."
E0218 00:21:19.037[15](https://github.com/project-akri/akri/actions/runs/4208520783/jobs/7304830454#step:12:16)1    5389 remote_image.go:119] "ListImages with filter from image service failed" err="rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing dial unix /var/run/dockershim.sock: connect: no such file or directory\"" filter="&ImageFilter{Image:&ImageSpec{Image:,Annotations:map[string]string{},},}"
time="2023-02-18T00:21:19Z" level=fatal msg="listing images: rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing dial unix /var/run/dockershim.sock: connect: no such file or directory\""
```
**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR has an associated PR with documentation in [akri-docs](https://github.com/project-akri/akri-docs)
- [ ] this PR contains unit tests
- [ ] added code adheres to standard Rust formatting (`cargo fmt`)
- [ ] code builds properly (`cargo build`)
- [ ] code is free of common mistakes (`cargo clippy`)
- [ ] all Akri tests succeed (`cargo test`)
- [ ] inline documentation builds (`cargo doc`)
- [ ] all commits pass the [DCO bot check](https://probot.github.io/apps/dco/) by being signed off -- see the failing DCO check for instructions on how to retroactively sign commits