### PR TITLE
udev: Add devnode to mounts not devpath

### DIFF
--- a/discovery-handlers/udev/src/discovery_handler.rs
+++ b/discovery-handlers/udev/src/discovery_handler.rs
@@ -84,20 +84,23 @@ impl DiscoveryHandler for DiscoveryHandlerImpl {
                     .into_iter()
                     .map(|(path, node)| {
                         let mut properties = std::collections::HashMap::new();
+                        let mut mounts = Vec::new();
                         if let Some(devnode) = node {
-                            properties.insert(super::UDEV_DEVNODE_LABEL_ID.to_string(), devnode);
+                            properties
+                                .insert(super::UDEV_DEVNODE_LABEL_ID.to_string(), devnode.clone());
+                            mounts.push(Mount {
+                                container_path: devnode.clone(),
+                                host_path: devnode,
+                                read_only: true,
+                            });
                         }
                         properties.insert(super::UDEV_DEVPATH_LABEL_ID.to_string(), path.clone());
-                        let mount = Mount {
-                            container_path: path.clone(),
-                            host_path: path.clone(),
-                            read_only: true,
-                        };
+
                         // TODO: use device spec
                         Device {
                             id: path,
                             properties,
-                            mounts: vec![mount],
+                            mounts,
                             device_specs: Vec::default(),
                         }
                     })


### PR DESCRIPTION


<!--  Thank you for contributing to the Akri repo! Before submitting this PR, please make sure:
1. Read the Contributing Guide before submitting your PR: https://docs.akri.sh/community/contributing
2. Decide whether you need to add any labels to your PR, such as `same version` if the version should not be changed and your change will trigger the version check workflow. This will cause the workflow to automatically succeed: https://github.com/project-akri/akri/blob/main/.github/workflows/check-versioning.yml
3. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context. -->

**What this PR does / why we need it**:
The udev discovery handler currently adds the udev devpath to the device mounts, this doesn't allow access to the devnode and moreover said devpath is not a correct absolute path (it is relative to `/sys`).

This PR changes the current behavior to add the devnode (if any) to the device mounts instead of the (wrong) sysfs devpath.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR has an associated PR with documentation in [akri-docs](https://github.com/project-akri/akri-docs)
- [ ] this PR contains unit tests
- [] added code adheres to standard Rust formatting (`cargo fmt`)
- [] code builds properly (`cargo build`)
- [] code is free of common mistakes (`cargo clippy`)
- [] all Akri tests succeed (`cargo test`)
- [] inline documentation builds (`cargo doc`)
- [ ] all commits pass the [DCO bot check](https://probot.github.io/apps/dco/) by being signed off -- see the failing DCO check for instructions on how to retroactively sign commits