### PR TITLE
Upgrade Rust CI actions to maintained ones

### DIFF
--- a/.github/workflows/build-rust-code.yml
+++ b/.github/workflows/build-rust-code.yml
@@ -72,10 +72,9 @@ jobs:
         persist-credentials: false
 
     - name: Rust install
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@master
       with:
         toolchain: 1.68.1
-        override: true
         components: clippy, rustfmt
 
     - name: Build production rust for ${{ matrix.arch.label }}

--- a/.github/workflows/check-rust.yml
+++ b/.github/workflows/check-rust.yml
@@ -31,7 +31,7 @@ jobs:
         persist-credentials: false
 
     - name: Rust install
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@master
       with:
         toolchain: 1.68.1
         components: clippy, rustfmt

--- a/.github/workflows/check-rust.yml
+++ b/.github/workflows/check-rust.yml
@@ -31,10 +31,9 @@ jobs:
         persist-credentials: false
 
     - name: Rust install
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@stable
       with:
         toolchain: 1.68.1
-        override: true
         components: clippy, rustfmt
     - name: Install Linux requirements
       run: |

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -14,7 +14,7 @@ jobs:
         id: cargo-audit
         if: github.repository == 'project-akri/akri' # only run on main repo and not forks
         continue-on-error: true
-        uses: actions-rs/audit-check@v1
+        uses: rustsec/audit-check@v1.4.1
         with:
           # token is only used for creating the audit report and does not impact the 
           # functionality or success/failure of the job in case the token is unavailable 


### PR DESCRIPTION
**What this PR does / why we need it**:
Upgrade the Rust actions not upgraded in PR #548. Switched to other actions as the current ones are not maintained anymore.
Fix #579
**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR has an associated PR with documentation in [akri-docs](https://github.com/project-akri/akri-docs)
- [ ] this PR contains unit tests
- [ ] added code adheres to standard Rust formatting (`cargo fmt`)
- [ ] code builds properly (`cargo build`)
- [ ] code is free of common mistakes (`cargo clippy`)
- [ ] all Akri tests succeed (`cargo test`)
- [ ] inline documentation builds (`cargo doc`)
- [x] all commits pass the [DCO bot check](https://probot.github.io/apps/dco/) by being signed off -- see the failing DCO check for instructions on how to retroactively sign commits