### PR TITLE
Add K8S 1.27 to test cases and remove 1.23

### DIFF
--- a/.github/workflows/run-test-cases.yml
+++ b/.github/workflows/run-test-cases.yml
@@ -103,30 +103,30 @@ jobs:
       fail-fast: false
       matrix:
         kube:
-          - runtime: MicroK8s-1.23
-            version: 1.23/stable
           - runtime: MicroK8s-1.24
             version: 1.24/stable
           - runtime: MicroK8s-1.25
             version: 1.25/stable
           - runtime: MicroK8s-1.26
             version: 1.26/stable
-          - runtime: K3s-1.23
-            version: v1.23.15+k3s1
+          - runtime: MicroK8s-1.27
+            version: 1.27/stable
           - runtime: K3s-1.24
-            version: v1.24.12+k3s1
+            version: v1.24.13+k3s1
           - runtime: K3s-1.25
-            version: v1.25.8+k3s1
+            version: v1.25.9+k3s1
           - runtime: K3s-1.26
-            version: v1.26.3+k3s1
-          - runtime: Kubernetes-1.23
-            version: 1.23.15-00
+            version: v1.26.4+k3s1
+          - runtime: K3s-1.27
+            version: v1.27.1+k3s1
           - runtime: Kubernetes-1.24
-            version: 1.24.12-00
+            version: 1.24.13-00
           - runtime: Kubernetes-1.25
-            version: 1.25.8-00
+            version: 1.25.9-00
           - runtime: Kubernetes-1.26
-            version: 1.26.3-00
+            version: 1.26.4-00
+          - runtime: Kubernetes-1.27
+            version: 1.27.1-00
         test:
           - case: end-to-end
             file: test/run-end-to-end.py


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR aims to add K8S 1.27, bump supported patch versions and remove unsupported 1.23 version
**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR has an associated PR with documentation in [akri-docs](https://github.com/project-akri/akri-docs)
- [ ] this PR contains unit tests
- [ ] added code adheres to standard Rust formatting (`cargo fmt`)
- [ ] code builds properly (`cargo build`)
- [ ] code is free of common mistakes (`cargo clippy`)
- [ ] all Akri tests succeed (`cargo test`)
- [ ] inline documentation builds (`cargo doc`)
- [x] all commits pass the [DCO bot check](https://probot.github.io/apps/dco/) by being signed off -- see the failing DCO check for instructions on how to retroactively sign commits