### PR TITLE
build: Fix intermediate dotnet openCV image

### DIFF
--- a/build/containers/intermediate/Dockerfile.opencvsharp-build
+++ b/build/containers/intermediate/Dockerfile.opencvsharp-build
@@ -9,8 +9,8 @@
 # Makefile's USE_OPENCV_BASE_VERSION.
 #
 
-ARG PLATFORM_TAG=3.1-buster-slim
-FROM mcr.microsoft.com/dotnet/core/aspnet:${PLATFORM_TAG} AS base
+ARG PLATFORM=
+FROM mcr.microsoft.com/dotnet/aspnet:3.1-buster-slim${PLATFORM} AS base
 WORKDIR /app
 
 # Link the container to the Akri repository
@@ -104,48 +104,51 @@ RUN cd ${OPENCV_INSTALLATION_DIR}/opencv-${OPENCV_VERSION} && \
     -D BUILD_opencv_wechat_qrcode=OFF \
     -D WITH_GSTREAMER=OFF \
     -D OPENCV_ENABLE_NONFREE=ON \
-    .. && make -j$(grep -c ^processor /proc/cpuinfo) && \
+    .. && make -j$(nproc) && \
 	make install -j8 && \
 	ldconfig
 
 RUN cd ${OPENCV_INSTALLATION_DIR} && \
-	git clone https://github.com/shimat/opencvsharp.git opencvsharp && \
-	cd opencvsharp && \
-	git fetch --all --tags --prune && git checkout ${OPENCV_SHARP_VERSION} && \
-	cd src && \
+	git clone --depth=1 --branch=${OPENCV_SHARP_VERSION} https://github.com/shimat/opencvsharp.git opencvsharp && \
+	cd opencvsharp/src && \
 	mkdir build && \
 	cd build && \
 	cmake -D CMAKE_INSTALL_PREFIX=${OPENCV_INSTALLATION_DIR} .. && \
-	make -j$(grep -c ^processor /proc/cpuinfo) && \
+	make -j$(nproc) && \
 	make install && \
 	ldconfig && \
 	cp OpenCvSharpExtern/libOpenCvSharpExtern.so /usr/lib
 
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS build-dotnet-env
+# Don't force architecture here as it won't be working as expected
+FROM mcr.microsoft.com/dotnet/sdk:3.1-buster AS build-dotnet-env
+
+ARG PLATFORM
+
+ENV OPENCV_SHARP_VERSION="4.5.3.20210821"
+ENV ARCH=${PLATFORM:--x64}
+
 WORKDIR /
 COPY --from=base /usr/lib/libOpenCvSharpExtern.so ./
-RUN git clone https://github.com/shimat/opencvsharp.git && \
-	cd opencvsharp && \
-	git fetch --all --tags --prune && git checkout ${OPENCV_SHARP_VERSION}
+RUN git clone --depth=1 --branch=${OPENCV_SHARP_VERSION} https://github.com/shimat/opencvsharp.git
 
 # Install Build the C# part of OpenCvSharp
 RUN cd /opencvsharp/src/OpenCvSharp && \
-    dotnet build -c Release -f netstandard2.0 
+    dotnet build -r linux${ARCH%32} -c Release -f netstandard2.0 
 
 RUN cd /opencvsharp/src/OpenCvSharp.Extensions && \
-    dotnet build -c Release -f netstandard2.0 
+    dotnet build -r linux${ARCH%32} -c Release -f netstandard2.0 
 
 RUN mkdir /opencvsharp/build && \
     cd /opencvsharp/build && \
-    cp /opencvsharp/src/OpenCvSharp/bin/Release/netstandard2.0/* . && \
-    cp /opencvsharp/src/OpenCvSharp.Extensions/bin/Release/netstandard2.0/* .
+    cp /opencvsharp/src/OpenCvSharp/bin/$([ -n "$PLATFORM" ] && echo "*")/Release/netstandard2.0/*/* . && \
+    cp /opencvsharp/src/OpenCvSharp.Extensions/bin/$([ -n "$PLATFORM" ] && echo "*")/Release/netstandard2.0/*/* .
 
 # Copy over OpenCvSharp binaries and OpenCvSharpExtern shared library
-FROM mcr.microsoft.com/dotnet/core/aspnet:${PLATFORM_TAG}
+FROM mcr.microsoft.com/dotnet/aspnet:3.1-buster-slim${PLATFORM}
 WORKDIR /app
 COPY --from=build-dotnet-env /opencvsharp/build ./
 COPY --from=build-dotnet-env /libOpenCvSharpExtern.so /usr/lib
-# Install OpenCVSharpEntern dependencies
+# Install OpenCVSharpExtern dependencies
 RUN apt-get update && apt-get -y install --no-install-recommends \
     libgtk2.0-dev \
     libavcodec-dev \

--- a/build/intermediate-containers.mk
+++ b/build/intermediate-containers.mk
@@ -1,7 +1,7 @@
 
 BUILD_RUST_CROSSBUILD_VERSION = 0.0.7
 
-BUILD_OPENCV_BASE_VERSION = 0.0.9
+BUILD_OPENCV_BASE_VERSION = 0.0.10
 
 CROSS_VERSION = 0.1.16
 
@@ -18,15 +18,16 @@ opencv-base: opencv-base-build opencv-base-docker-per-arch
 opencv-base-build: opencv-base-build-amd64 opencv-base-build-arm32 opencv-base-build-arm64
 opencv-base-build-amd64:
 ifeq (1, ${BUILD_AMD64})
-	docker build $(CACHE_OPTION) -f $(INTERMEDIATE_DOCKERFILE_DIR)/Dockerfile.opencvsharp-build . -t $(PREFIX)/opencvsharp-build:$(BUILD_OPENCV_BASE_VERSION)-$(AMD64_SUFFIX) --build-arg PLATFORM_TAG=3.1-buster-slim
+# No PLATFORM build arg for amd64 as the aspnet images for amd64 are not suffixed
+	docker build $(CACHE_OPTION) -f $(INTERMEDIATE_DOCKERFILE_DIR)/Dockerfile.opencvsharp-build . -t $(PREFIX)/opencvsharp-build:$(BUILD_OPENCV_BASE_VERSION)-$(AMD64_SUFFIX)
 endif
 opencv-base-build-arm32:
 ifeq (1, ${BUILD_ARM32})
-	docker build $(CACHE_OPTION) -f $(INTERMEDIATE_DOCKERFILE_DIR)/Dockerfile.opencvsharp-build . -t $(PREFIX)/opencvsharp-build:$(BUILD_OPENCV_BASE_VERSION)-$(ARM32V7_SUFFIX) --build-arg PLATFORM_TAG=3.1-buster-slim-$(ARM32V7_SUFFIX)
+	docker build $(CACHE_OPTION) -f $(INTERMEDIATE_DOCKERFILE_DIR)/Dockerfile.opencvsharp-build . -t $(PREFIX)/opencvsharp-build:$(BUILD_OPENCV_BASE_VERSION)-$(ARM32V7_SUFFIX) --build-arg PLATFORM=-$(ARM32V7_SUFFIX)
 endif
 opencv-base-build-arm64:
 ifeq (1, ${BUILD_ARM64})
-	docker build $(CACHE_OPTION) -f $(INTERMEDIATE_DOCKERFILE_DIR)/Dockerfile.opencvsharp-build . -t $(PREFIX)/opencvsharp-build:$(BUILD_OPENCV_BASE_VERSION)-$(ARM64V8_SUFFIX) --build-arg PLATFORM_TAG=3.1-buster-slim-$(ARM64V8_SUFFIX)
+	docker build $(CACHE_OPTION) -f $(INTERMEDIATE_DOCKERFILE_DIR)/Dockerfile.opencvsharp-build . -t $(PREFIX)/opencvsharp-build:$(BUILD_OPENCV_BASE_VERSION)-$(ARM64V8_SUFFIX) --build-arg PLATFORM=-$(ARM64V8_SUFFIX)
 endif
 opencv-base-docker-per-arch: opencv-base-docker-per-arch-amd64 opencv-base-docker-per-arch-arm32 opencv-base-docker-per-arch-arm64
 opencv-base-docker-per-arch-amd64:


### PR DESCRIPTION


**What this PR does / why we need it**:

The image was built using the wrong version of opencvsharp, fix this.

Also switch to shallow clone to reduce build time (a bit).

Should fix #580 

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR has an associated PR with documentation in [akri-docs](https://github.com/project-akri/akri-docs)
- [ ] this PR contains unit tests
- [ ] added code adheres to standard Rust formatting (`cargo fmt`)
- [ ] code builds properly (`cargo build`)
- [ ] code is free of common mistakes (`cargo clippy`)
- [ ] all Akri tests succeed (`cargo test`)
- [ ] inline documentation builds (`cargo doc`)
- [x] all commits pass the [DCO bot check](https://probot.github.io/apps/dco/) by being signed off -- see the failing DCO check for instructions on how to retroactively sign commits