### PR TITLE
Add linuxOnly node selector for discovery handlers

### DIFF
--- a/deployment/helm/templates/custom-discovery-handler.yaml
+++ b/deployment/helm/templates/custom-discovery-handler.yaml
@@ -46,9 +46,14 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.custom.discovery.nodeSelectors }}
+      {{- if or .Values.custom.discovery.linuxOnly .Values.custom.discovery.nodeSelectors }}
       nodeSelector:
-      {{- toYaml .Values.custom.discovery.nodeSelectors | nindent 8 }}
+        {{- if .Values.agent.linuxOnly }}
+        "kubernetes.io/os": linux
+        {{- end }}
+        {{- if .Values.custom.discovery.nodeSelectors }}
+          {{- toYaml .Values.custom.discovery.nodeSelectors | nindent 8 }}
+        {{- end }}
       {{- end }}
       volumes:
       - name: discovery-handlers

--- a/deployment/helm/templates/debug-echo-discovery-handler.yaml
+++ b/deployment/helm/templates/debug-echo-discovery-handler.yaml
@@ -60,9 +60,14 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.debugEcho.discovery.nodeSelectors }}
+      {{- if or .Values.debugEcho.discovery.linuxOnly .Values.debugEcho.discovery.nodeSelectors }}
       nodeSelector:
-      {{- toYaml .Values.debugEcho.discovery.nodeSelectors | nindent 8 }}
+        {{- if .Values.debugEcho.discovery.linuxOnly }}
+        "kubernetes.io/os": linux
+        {{- end }}
+        {{- if .Values.debugEcho.discovery.nodeSelectors }}
+          {{- toYaml .Values.debugEcho.discovery.nodeSelectors | nindent 8 }}
+        {{- end }}
       {{- end }}
       volumes:
       - name: discovery-handlers

--- a/deployment/helm/templates/onvif-discovery-handler.yaml
+++ b/deployment/helm/templates/onvif-discovery-handler.yaml
@@ -60,9 +60,14 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.onvif.discovery.nodeSelectors }}
+      {{- if or .Values.onvif.discovery.linuxOnly .Values.onvif.discovery.nodeSelectors }}
       nodeSelector:
-      {{- toYaml .Values.onvif.discovery.nodeSelectors | nindent 8 }}
+        {{- if .Values.onvif.discovery.linuxOnly }}
+        "kubernetes.io/os": linux
+        {{- end }}
+        {{- if .Values.onvif.discovery.nodeSelectors }}
+          {{- toYaml .Values.onvif.discovery.nodeSelectors | nindent 8 }}
+        {{- end }}
       {{- end }}
       volumes:
       - name: discovery-handlers

--- a/deployment/helm/templates/opcua-discovery-handler.yaml
+++ b/deployment/helm/templates/opcua-discovery-handler.yaml
@@ -58,9 +58,14 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.opcua.discovery.nodeSelectors }}
+      {{- if or .Values.opcua.discovery.linuxOnly .Values.opcua.discovery.nodeSelectors }}
       nodeSelector:
-      {{- toYaml .Values.opcua.discovery.nodeSelectors | nindent 8 }}
+        {{- if .Values.opcua.discovery.linuxOnly }}
+        "kubernetes.io/os": linux
+        {{- end }}
+        {{- if .Values.opcua.discovery.nodeSelectors }}
+          {{- toYaml .Values.opcua.discovery.nodeSelectors | nindent 8 }}
+        {{- end }}
       {{- end }}
       volumes:
       - name: discovery-handlers

--- a/deployment/helm/templates/udev-discovery-handler.yaml
+++ b/deployment/helm/templates/udev-discovery-handler.yaml
@@ -64,9 +64,14 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.udev.discovery.nodeSelectors }}
+      {{- if or .Values.udev.discovery.linuxOnly .Values.udev.discovery.nodeSelectors }}
       nodeSelector:
-      {{- toYaml .Values.udev.discovery.nodeSelectors | nindent 8 }}
+        {{- if .Values.udev.discovery.linuxOnly }}
+        "kubernetes.io/os": linux
+        {{- end }}
+        {{- if .Values.udev.discovery.nodeSelectors }}
+          {{- toYaml .Values.udev.discovery.nodeSelectors | nindent 8 }}
+        {{- end }}
       {{- end }}
       volumes:
       - name: discovery-handlers

--- a/deployment/helm/values.yaml
+++ b/deployment/helm/values.yaml
@@ -254,6 +254,8 @@ custom:
     useNetworkConnection: false
     # port specifies (when useNetworkConnection is true) the port on which the discovery handler advertises its discovery service
     port: 10000
+    # linuxOnly dictates whether the discovery handler will only run on a linux node
+    linuxOnly: true
     # nodeSelectors is the array of nodeSelectors used to target nodes for the discovery handler to run on
     # This can be set from the helm command line using `--set custom.discovery.nodeSelectors.label="value"`
     nodeSelectors: {}
@@ -393,6 +395,8 @@ debugEcho:
     useNetworkConnection: false
     # port specifies (when useNetworkConnection is true) the port on which the discovery handler advertises its discovery service
     port: 10000
+    # linuxOnly dictates whether the discovery handler will only run on a linux node
+    linuxOnly: true
     # nodeSelectors is the array of nodeSelectors used to target nodes for the discovery handler to run on
     # This can be set from the helm command line using `--set debugEcho.discovery.nodeSelectors.label="value"`
     nodeSelectors: {}
@@ -537,6 +541,8 @@ onvif:
     useNetworkConnection: false
     # port specifies (when useNetworkConnection is true) the port on which the discovery handler advertises its discovery service
     port: 10000
+    # linuxOnly dictates whether the discovery handler will only run on a linux node
+    linuxOnly: true
     # nodeSelectors is the array of nodeSelectors used to target nodes for the discovery handler to run on
     # This can be set from the helm command line using `--set onvif.discovery.nodeSelectors.label="value"`
     nodeSelectors: {}
@@ -680,6 +686,8 @@ opcua:
     useNetworkConnection: false
     # port specifies (when useNetworkConnection is true) the port on which the discovery handler advertises its discovery service
     port: 10000
+    # linuxOnly dictates whether the discovery handler will only run on a linux node
+    linuxOnly: true
     # nodeSelectors is the array of nodeSelectors used to target nodes for the discovery handler to run on
     # This can be set from the helm command line using `--set opcua.discovery.nodeSelectors.label="value"`
     nodeSelectors: {}
@@ -816,6 +824,8 @@ udev:
     useNetworkConnection: false
     # port specifies (when useNetworkConnection is true) the port on which the discovery handler advertises its discovery service
     port: 10000
+    # linuxOnly dictates whether the discovery handler will only run on a linux node
+    linuxOnly: true
     # nodeSelectors is the array of nodeSelectors used to target nodes for the discovery handler to run on
     # This can be set from the helm command line using `--set udev.discovery.nodeSelectors.label="value"`
     nodeSelectors: {}


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix #598
**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR has an associated PR with documentation in [akri-docs](https://github.com/project-akri/akri-docs)
- [ ] this PR contains unit tests
- [ ] added code adheres to standard Rust formatting (`cargo fmt`)
- [ ] code builds properly (`cargo build`)
- [ ] code is free of common mistakes (`cargo clippy`)
- [ ] all Akri tests succeed (`cargo test`)
- [ ] inline documentation builds (`cargo doc`)
- [x] all commits pass the [DCO bot check](https://probot.github.io/apps/dco/) by being signed off -- see the failing DCO check for instructions on how to retroactively sign commits