### PR TITLE
Add Nicolas Belouin (@diconico07) to CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
 # This file is described here:  https://help.github.com/en/articles/about-code-owners
 
 # Global Owners: These members are Core Maintainers of Akri
-* @kate-goldenring @bfjelds @romoh @jiria @adithyaj @johnsonshih
+* @kate-goldenring @bfjelds @romoh @jiria @adithyaj @johnsonshih @diconico07


### PR DESCRIPTION
**What this PR does / why we need it**:
Add myself (Nicolas Belouin) as maintainer for akri.

**Special notes for your reviewer**:
This requires giving write access to the repository before merge

**If applicable**:
- [ ] this PR has an associated PR with documentation in [akri-docs](https://github.com/project-akri/akri-docs)
- [ ] this PR contains unit tests
- [ ] added code adheres to standard Rust formatting (`cargo fmt`)
- [ ] code builds properly (`cargo build`)
- [ ] code is free of common mistakes (`cargo clippy`)
- [ ] all Akri tests succeed (`cargo test`)
- [ ] inline documentation builds (`cargo doc`)
- [x] all commits pass the [DCO bot check](https://probot.github.io/apps/dco/) by being signed off -- see the failing DCO check for instructions on how to retroactively sign commits