### PR TITLE
correct test case test_validate_valid_jobspec

### DIFF
--- a/webhooks/validating/configuration/src/main.rs
+++ b/webhooks/validating/configuration/src/main.rs
@@ -807,7 +807,7 @@ mod tests {
     async fn test_validate_valid_jobspec() {
         let mut app = test::init_service(App::new().service(validate)).await;
         let valid: AdmissionReview =
-            serde_json::from_str(&get_valid_admission_review_with_broker_pod_spec())
+            serde_json::from_str(&get_valid_admission_review_with_broker_job_spec())
                 .expect("v1.AdmissionReview JSON");
         let rqst = test::TestRequest::post()
             .uri("/validate")


### PR DESCRIPTION
<!--  Thank you for contributing to the Akri repo! Before submitting this PR, please make sure:
1. Read the Contributing Guide before submitting your PR: https://docs.akri.sh/community/contributing
2. Decide whether you need to add any labels to your PR, such as `same version` if the version should not be changed and your change will trigger the version check workflow. This will cause the workflow to automatically succeed: https://github.com/project-akri/akri/blob/main/.github/workflows/check-versioning.yml
3. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context. -->

**What this PR does / why we need it**:
There is a typo in the unit test test_validate_valid_jobspec, it should test valid job spec, not valid pod spec.
**Special notes for your reviewer**:

/add-same-version-label

**If applicable**:
- [ ] this PR has an associated PR with documentation in [akri-docs](https://github.com/project-akri/akri-docs)
- [ ] this PR contains unit tests
- [ ] added code adheres to standard Rust formatting (`cargo fmt`)
- [x] code builds properly (`cargo build`)
- [x] code is free of common mistakes (`cargo clippy`)
- [x] all Akri tests succeed (`cargo test`)
- [ ] inline documentation builds (`cargo doc`)
- [x] all commits pass the [DCO bot check](https://probot.github.io/apps/dco/) by being signed off -- see the failing DCO check for instructions on how to retroactively sign commits