### PR TITLE
Add udev e2e tests

### DIFF
--- a/test/e2e/test_udev.py
+++ b/test/e2e/test_udev.py
@@ -1,0 +1,86 @@
+from pathlib import Path
+import time
+
+import yaml
+import pytest
+import kubernetes
+from helpers import assert_akri_instances_present, check_akri_is_healthy
+
+
+discovery_handlers = ["udev"]
+
+
+@pytest.fixture
+def dev_null_config(akri_version):
+    with open(Path(__file__).parent / "yaml/udevDevNullConfiguration.yaml") as f:
+        body = yaml.safe_load(f)
+    client = kubernetes.client.CustomObjectsApi()
+    version = f'v{akri_version.split(".")[0]}'
+    client.create_namespaced_custom_object(
+        "akri.sh", version, "default", "configurations", body
+    )
+
+    yield body["metadata"]["name"]
+
+    client.delete_namespaced_custom_object(
+        "akri.sh", version, "default", "configurations", body["metadata"]["name"]
+    )
+
+
+def test_dev_null_config(akri_version, dev_null_config):
+    check_akri_is_healthy(discovery_handlers)
+    assert_akri_instances_present(akri_version, dev_null_config, 1)
+
+
+@pytest.fixture
+def grouped_config(akri_version):
+    v1_core = kubernetes.client.CoreV1Api()
+    pods = v1_core.list_namespaced_pod(
+        "default",
+        label_selector=f"app.kubernetes.io/name=akri-udev-discovery",
+        field_selector="status.phase=Running",
+    ).items
+    base_command = ["/bin/sh", "-c"]
+    # This command will get the ID_PATH to use to get a device with many "subdevices"
+    command = "grep -hr ID_PATH= /run/udev/data | sort | uniq -cd | sort -h | tail -1 | cut -d '=' -f 2"
+    paths = set()
+    # Get the ID_PATH we can use
+    for pod in pods:
+        resp = kubernetes.stream.stream(
+            v1_core.connect_get_namespaced_pod_exec,
+            pod.metadata.name,
+            "default",
+            command=base_command + [command],
+            stdout=True,
+            stdin=False,
+            stderr=True,
+            tty=False,
+            _preload_content=False,
+        )
+        try:
+            paths.add(resp.readline_stdout(timeout=3).strip())
+        except:
+            pytest.skip("No udev ?")
+    if len(paths) == 0:
+        pytest.skip("No groupable devices found")
+    path = paths.pop()
+
+    with open(Path(__file__).parent / "yaml/udevGroupedConfiguration.yaml") as f:
+        body = yaml.safe_load(f)
+    body["spec"]["discoveryHandler"]["discoveryDetails"] = body["spec"][
+        "discoveryHandler"
+    ]["discoveryDetails"].format(path)
+    client = kubernetes.client.CustomObjectsApi()
+    version = f'v{akri_version.split(".")[0]}'
+    client.create_namespaced_custom_object(
+        "akri.sh", version, "default", "configurations", body
+    )
+    yield body["metadata"]["name"]
+    client.delete_namespaced_custom_object(
+        "akri.sh", version, "default", "configurations", body["metadata"]["name"]
+    )
+
+
+def test_grouped_config(akri_version, grouped_config):
+    check_akri_is_healthy(discovery_handlers)
+    assert_akri_instances_present(akri_version, grouped_config, 1)

--- a/test/e2e/yaml/udevDevNullConfiguration.yaml
+++ b/test/e2e/yaml/udevDevNullConfiguration.yaml
@@ -1,0 +1,10 @@
+apiVersion: akri.sh/v0
+kind: Configuration
+metadata:
+  name: akri-udev-dev-null
+spec:
+  discoveryHandler: 
+    name: udev
+    discoveryDetails: |+
+      udevRules:
+        - KERNEL=="null"

--- a/test/e2e/yaml/udevGroupedConfiguration.yaml
+++ b/test/e2e/yaml/udevGroupedConfiguration.yaml
@@ -1,0 +1,11 @@
+apiVersion: akri.sh/v0
+kind: Configuration
+metadata:
+  name: akri-udev-grouped
+spec:
+  discoveryHandler: 
+    name: udev
+    discoveryDetails: |+
+      groupRecursive: true
+      udevRules:
+        - ENV{{ID_PATH}}=="{}"


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR introduces a new testsuite that ensures the udev Discover
Handler is able to discover a basic device, and a grouped device (if
any available).

**Special notes for your reviewer**:
This PR is built on top of #623 only the last commit really belongs to this PR

**If applicable**:
- [ ] this PR has an associated PR with documentation in [akri-docs](https://github.com/project-akri/akri-docs)
- [ ] this PR contains unit tests
- [ ] added code adheres to standard Rust formatting (`cargo fmt`)
- [ ] code builds properly (`cargo build`)
- [ ] code is free of common mistakes (`cargo clippy`)
- [ ] all Akri tests succeed (`cargo test`)
- [ ] inline documentation builds (`cargo doc`)
- [ ] all commits pass the [DCO bot check](https://probot.github.io/apps/dco/) by being signed off -- see the failing DCO check for instructions on how to retroactively sign commits