### PR TITLE
Fix e2e tests for local version with discovery handlers

### DIFF
--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -100,6 +100,14 @@ def install_akri(request, distribution_config, pytestconfig, akri_version):
                     "agent.allowDebugEcho=true,debugEcho.configuration.shared=false",
                 ]
             )
+        if pytestconfig.getoption("--use-local"):
+            local_tag = pytestconfig.getoption("--local-tag", "pr-amd64")
+            helm_install_command.extend(
+                [
+                    "--set",
+                    f"{discovery_handler}.discovery.image.pullPolicy=Never,"
+                    f"{discovery_handler}.discovery.image.tag={local_tag}"
+                ])
         helm_install_command.extend(
             [
                 "--set",


### PR DESCRIPTION
**What this PR does / why we need it**:
This fixes an issue with the new e2e tests framework that got missed during review, it makes the e2e tests to fail for all new PRs (saw that with #533 )

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR has an associated PR with documentation in [akri-docs](https://github.com/project-akri/akri-docs)
- [ ] this PR contains unit tests
- [ ] added code adheres to standard Rust formatting (`cargo fmt`)
- [ ] code builds properly (`cargo build`)
- [ ] code is free of common mistakes (`cargo clippy`)
- [ ] all Akri tests succeed (`cargo test`)
- [ ] inline documentation builds (`cargo doc`)
- [x] all commits pass the [DCO bot check](https://probot.github.io/apps/dco/) by being signed off -- see the failing DCO check for instructions on how to retroactively sign commits