### PR TITLE
chore(e2e): upgrade k8s version & repo

### DIFF
--- a/.github/workflows/run-test-cases.yml
+++ b/.github/workflows/run-test-cases.yml
@@ -201,10 +201,11 @@ jobs:
       - if: startsWith(matrix.kube.runtime, 'k8s')
         name: Install Kubernetes
         run: |
+          SHORTVERSION=$(cut -d '.' -f 1,2 <<< "${{ matrix.kube.version }}")
           sudo apt-get update -y
           sudo apt-get install -y apt-transport-https ca-certificates curl
-          sudo curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://dl.k8s.io/apt/doc/apt-key.gpg
-          echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+          curl -fsSL https://pkgs.k8s.io/core:/stable:/v${SHORTVERSION}/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+          echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v${SHORTVERSION}/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
           sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker.gpg
           echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list
           sudo apt-get update
@@ -238,15 +239,9 @@ jobs:
 
           verlte() { [  "$1" = "`echo -e "$1\n$2" | sort -V | head -n1`" ] ; }
           verlt()  { [ "$1" = "$2" ] && return 1 || verlte $1 $2 ; }
-          # Kubernetes 1.24+ has control plane label
-          if verlte "1.24.0" "${{ matrix.kube.version }}" ; then
-            kubectl taint nodes --all node-role.kubernetes.io/control-plane-
-          fi
-          # Kubernetes before 1.25 has master label
-          if verlt "${{ matrix.kube.version }}" "1.25.0" ; then
-            kubectl taint nodes --all node-role.kubernetes.io/master-
-          fi
-
+          # Remove control plane label
+          kubectl taint nodes --all node-role.kubernetes.io/control-plane-
+          
           until kubectl get node ${HOSTNAME,,} -o jsonpath='{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status}' | grep 'Ready=True'; do echo "waiting for kubernetes to become ready"; sleep 10; done
 
       - if: startsWith(matrix.kube.runtime, 'k8s')

--- a/.github/workflows/run-test-cases.yml
+++ b/.github/workflows/run-test-cases.yml
@@ -130,29 +130,29 @@ jobs:
       matrix:
         kube:
           - runtime: microk8s
-            version: 1.24/stable
-          - runtime: microk8s
             version: 1.25/stable
           - runtime: microk8s
             version: 1.26/stable
           - runtime: microk8s
             version: 1.27/stable
+          - runtime: microk8s
+            version: 1.28/stable
           - runtime: k3s
-            version: v1.24.13+k3s1
+            version: v1.25.13+k3s1
           - runtime: k3s
-            version: v1.25.9+k3s1
+            version: v1.26.8+k3s1
           - runtime: k3s
-            version: v1.26.4+k3s1
+            version: v1.27.5+k3s1
           - runtime: k3s
-            version: v1.27.1+k3s1
+            version: v1.28.1+k3s1
           - runtime: k8s
-            version: 1.24.13-00
+            version: 1.25.13-00
           - runtime: k8s
-            version: 1.25.9-00
+            version: 1.26.8-00
           - runtime: k8s
-            version: 1.26.4-00
+            version: 1.27.5-00
           - runtime: k8s
-            version: 1.27.1-00
+            version: 1.28.1-00
 
     steps:
       - name: Checkout the head commit of the branch

--- a/.github/workflows/run-test-cases.yml
+++ b/.github/workflows/run-test-cases.yml
@@ -146,13 +146,13 @@ jobs:
           - runtime: k3s
             version: v1.28.1+k3s1
           - runtime: k8s
-            version: 1.25.13-00
+            version: 1.25.13
           - runtime: k8s
-            version: 1.26.8-00
+            version: 1.26.8
           - runtime: k8s
-            version: 1.27.5-00
+            version: 1.27.5
           - runtime: k8s
-            version: 1.28.1-00
+            version: 1.28.1
 
     steps:
       - name: Checkout the head commit of the branch
@@ -209,7 +209,7 @@ jobs:
           sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker.gpg
           echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list
           sudo apt-get update
-          sudo apt-get install -o Dpkg::Options::="--force-overwrite" -y --allow-downgrades kubelet=${{ matrix.kube.version }} kubeadm=${{ matrix.kube.version }} kubectl=${{ matrix.kube.version }} containerd.io
+          sudo apt-get install -o Dpkg::Options::="--force-overwrite" -y --allow-downgrades kubelet=${{ matrix.kube.version }}-* kubeadm=${{ matrix.kube.version }}-* kubectl=${{ matrix.kube.version }}-* containerd.io
           kubectl version && echo "kubectl return code: $?" || echo "kubectl return code: $?"
           kubeadm version && echo "kubeadm return code: $?" || echo "kubeadm return code: $?"
           kubelet --version && echo "kubelet return code: $?" || echo "kubelet return code: $?"


### PR DESCRIPTION
**What this PR does / why we need it**:

K8S 1.28 was released, it would be goot to test on this version.
More over, APT repos are moving to pkgs.k8s.io and they changed the structure. Old repo is freezing so migration is needed for further versions

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR has an associated PR with documentation in [akri-docs](https://github.com/project-akri/akri-docs)
- [ ] this PR contains unit tests
- [ ] added code adheres to standard Rust formatting (`cargo fmt`)
- [ ] code builds properly (`cargo build`)
- [ ] code is free of common mistakes (`cargo clippy`)
- [ ] all Akri tests succeed (`cargo test`)
- [ ] inline documentation builds (`cargo doc`)
- [x] all commits pass the [DCO bot check](https://probot.github.io/apps/dco/) by being signed off -- see the failing DCO check for instructions on how to retroactively sign commits