### PR TITLE
Add discovery response metrics to Agent

### DIFF
--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -9,7 +9,7 @@ mod util;
 
 use akri_shared::akri::{metrics::run_metrics_server, API_NAMESPACE};
 use log::{info, trace};
-use prometheus::{HistogramVec, IntGaugeVec};
+use prometheus::{opts, register_int_counter_vec, HistogramVec, IntCounterVec, IntGaugeVec};
 use std::{
     collections::HashMap,
     env,
@@ -33,6 +33,11 @@ lazy_static! {
     pub static ref INSTANCE_COUNT_METRIC: IntGaugeVec = prometheus::register_int_gauge_vec!("akri_instance_count", "Akri Instance Count", &["configuration", "is_shared"]).unwrap();
     // Reports the time to get discovery results, grouped by Configuration
     pub static ref DISCOVERY_RESPONSE_TIME_METRIC: HistogramVec = prometheus::register_histogram_vec!("akri_discovery_response_time", "Akri Discovery Response Time", &["configuration"]).unwrap();
+    // reports the result of discover requests, grouped by Discovery Handler name and whether it is succeeded
+    pub static ref DISCOVERY_RESPONSE_RESULT_METRIC: IntCounterVec = register_int_counter_vec!(
+        opts!("akri_discovery_response_result", "Akri Discovery Response Result"),
+        &["discovery_handler_name", "result"])
+        .expect("akri_discovery_response_result metric can be created");
 }
 
 /// This is the entry point for the Akri Agent.

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -28,12 +28,22 @@ use util::{
     slot_reconciliation::periodic_slot_reconciliation,
 };
 
+// Discovery request response time bucket (in seconds)
+const DISCOVERY_RESPONSE_TIME_BUCKETS: &[f64; 9] =
+    &[0.25, 0.5, 1.0, 1.5, 2.0, 3.0, 5.0, 10.0, 60.0];
+
 lazy_static! {
     // Reports the number of Instances visible to this node, grouped by Configuration and whether it is shared
     pub static ref INSTANCE_COUNT_METRIC: IntGaugeVec = prometheus::register_int_gauge_vec!("akri_instance_count", "Akri Instance Count", &["configuration", "is_shared"]).unwrap();
     // Reports the time to get discovery results, grouped by Configuration
-    pub static ref DISCOVERY_RESPONSE_TIME_METRIC: HistogramVec = prometheus::register_histogram_vec!("akri_discovery_response_time", "Akri Discovery Response Time", &["configuration"]).unwrap();
-    // reports the result of discover requests, grouped by Discovery Handler name and whether it is succeeded
+    pub static ref DISCOVERY_RESPONSE_TIME_METRIC: HistogramVec = prometheus::register_histogram_vec!(
+        "akri_discovery_response_time",
+        "Akri Discovery Response Time",
+        &["configuration"],
+        DISCOVERY_RESPONSE_TIME_BUCKETS.to_vec()
+        )
+        .expect("akri_discovery_response_time metric can be created");
+    // Reports the result of discover requests, grouped by Discovery Handler name and whether it is succeeded
     pub static ref DISCOVERY_RESPONSE_RESULT_METRIC: IntCounterVec = register_int_counter_vec!(
         opts!("akri_discovery_response_result", "Akri Discovery Response Result"),
         &["discovery_handler_name", "result"])

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -1,7 +1,5 @@
 extern crate hyper;
 #[macro_use]
-extern crate lazy_static;
-#[macro_use]
 extern crate log;
 #[macro_use]
 extern crate serde_derive;
@@ -9,7 +7,6 @@ mod util;
 
 use akri_shared::akri::{metrics::run_metrics_server, API_NAMESPACE};
 use log::{info, trace};
-use prometheus::{opts, register_int_counter_vec, HistogramVec, IntCounterVec, IntGaugeVec};
 use std::{
     collections::HashMap,
     env,
@@ -27,28 +24,6 @@ use util::{
     registration::{run_registration_server, DiscoveryHandlerName},
     slot_reconciliation::periodic_slot_reconciliation,
 };
-
-// Discovery request response time bucket (in seconds)
-const DISCOVERY_RESPONSE_TIME_BUCKETS: &[f64; 9] =
-    &[0.25, 0.5, 1.0, 1.5, 2.0, 3.0, 5.0, 10.0, 60.0];
-
-lazy_static! {
-    // Reports the number of Instances visible to this node, grouped by Configuration and whether it is shared
-    pub static ref INSTANCE_COUNT_METRIC: IntGaugeVec = prometheus::register_int_gauge_vec!("akri_instance_count", "Akri Instance Count", &["configuration", "is_shared"]).unwrap();
-    // Reports the time to get discovery results, grouped by Configuration
-    pub static ref DISCOVERY_RESPONSE_TIME_METRIC: HistogramVec = prometheus::register_histogram_vec!(
-        "akri_discovery_response_time",
-        "Akri Discovery Response Time",
-        &["configuration"],
-        DISCOVERY_RESPONSE_TIME_BUCKETS.to_vec()
-        )
-        .expect("akri_discovery_response_time metric can be created");
-    // Reports the result of discover requests, grouped by Discovery Handler name and whether it is succeeded
-    pub static ref DISCOVERY_RESPONSE_RESULT_METRIC: IntCounterVec = register_int_counter_vec!(
-        opts!("akri_discovery_response_result", "Akri Discovery Response Result"),
-        &["discovery_handler_name", "result"])
-        .expect("akri_discovery_response_result metric can be created");
-}
 
 /// This is the entry point for the Akri Agent.
 /// It must be built on unix systems, since the underlying libraries for the `DevicePluginService` unix socket connection are unix only.

--- a/agent/src/util/discovery_operator.rs
+++ b/agent/src/util/discovery_operator.rs
@@ -1,6 +1,6 @@
-use super::super::INSTANCE_COUNT_METRIC;
 #[cfg(any(test, feature = "agent-full"))]
 use super::embedded_discovery_handlers::get_discovery_handler;
+use super::metrics::INSTANCE_COUNT_METRIC;
 use super::{
     config_action::ConfigId,
     constants::SHARED_INSTANCE_OFFLINE_GRACE_PERIOD_SECS,
@@ -802,7 +802,7 @@ async fn get_discovery_property_value_from_config_map(
 }
 
 pub mod start_discovery {
-    use super::super::super::{DISCOVERY_RESPONSE_RESULT_METRIC, DISCOVERY_RESPONSE_TIME_METRIC};
+    use super::super::metrics::{DISCOVERY_RESPONSE_RESULT_METRIC, DISCOVERY_RESPONSE_TIME_METRIC};
     use super::super::registration::{DiscoveryDetails, DiscoveryHandlerEndpoint};
     // Use this `mockall` macro to automate importing a mock type in test mode, or a real type otherwise.
     use super::super::device_plugin_builder::{DevicePluginBuilder, DevicePluginBuilderInterface};

--- a/agent/src/util/metrics.rs
+++ b/agent/src/util/metrics.rs
@@ -1,0 +1,28 @@
+use lazy_static::lazy_static;
+use prometheus::{opts, register_int_counter_vec, HistogramVec, IntCounterVec, IntGaugeVec};
+
+// Discovery request response time bucket (in seconds)
+const DISCOVERY_RESPONSE_TIME_BUCKETS: &[f64; 9] =
+    &[0.25, 0.5, 1.0, 1.5, 2.0, 3.0, 5.0, 10.0, 60.0];
+
+lazy_static! {
+    // Reports the number of Instances visible to this node, grouped by Configuration and whether it is shared
+    pub static ref INSTANCE_COUNT_METRIC: IntGaugeVec = prometheus::register_int_gauge_vec!(
+        "akri_instance_count",
+        "Akri Instance Count",
+        &["configuration", "is_shared"])
+        .expect("akri_instance_count metric can be created");
+    // Reports the time to get discovery results, grouped by Configuration
+    pub static ref DISCOVERY_RESPONSE_TIME_METRIC: HistogramVec = prometheus::register_histogram_vec!(
+        "akri_discovery_response_time",
+        "Akri Discovery Response Time",
+        &["configuration"],
+        DISCOVERY_RESPONSE_TIME_BUCKETS.to_vec()
+        )
+        .expect("akri_discovery_response_time metric can be created");
+    // Reports the result of discover requests, grouped by Discovery Handler name and whether it is succeeded
+    pub static ref DISCOVERY_RESPONSE_RESULT_METRIC: IntCounterVec = register_int_counter_vec!(
+        opts!("akri_discovery_response_result", "Akri Discovery Response Result"),
+        &["discovery_handler_name", "result"])
+        .expect("akri_discovery_response_result metric can be created");
+}

--- a/agent/src/util/mod.rs
+++ b/agent/src/util/mod.rs
@@ -6,6 +6,7 @@ mod device_plugin_service;
 pub mod discovery_operator;
 #[cfg(any(test, feature = "agent-full"))]
 pub mod embedded_discovery_handlers;
+mod metrics;
 pub mod registration;
 pub mod slot_reconciliation;
 pub mod streaming_extension;


### PR DESCRIPTION
<!--  Thank you for contributing to the Akri repo! Before submitting this PR, please make sure:
1. Read the Contributing Guide before submitting your PR: https://docs.akri.sh/community/contributing
2. Decide whether you need to add any labels to your PR, such as `same version` if the version should not be changed and your change will trigger the version check workflow. This will cause the workflow to automatically succeed: https://github.com/project-akri/akri/blob/main/.github/workflows/check-versioning.yml
3. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context. -->

**What this PR does / why we need it**:
This PR adds two Prometheus metrics to Agent.
- akri_discovery_response_time: histogram of the discovery response latency from the time a Configuration is created/updated to the request sent to discovery handler
- akri_discovery_response_result: counter of the success/fail results when Agent invokes discover() to discovery handler
- 
**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR has an associated PR with documentation in [akri-docs](https://github.com/project-akri/akri-docs)
- [ ] this PR contains unit tests
- [ ] added code adheres to standard Rust formatting (`cargo fmt`)
- [ ] code builds properly (`cargo build`)
- [ ] code is free of common mistakes (`cargo clippy`)
- [ ] all Akri tests succeed (`cargo test`)
- [ ] inline documentation builds (`cargo doc`)
- [ ] all commits pass the [DCO bot check](https://probot.github.io/apps/dco/) by being signed off -- see the failing DCO check for instructions on how to retroactively sign commits