### PR TITLE
update node version in container build actions

### DIFF
--- a/.github/workflows/build-anomaly-detection-app-container.yml
+++ b/.github/workflows/build-anomaly-detection-app-container.yml
@@ -54,7 +54,7 @@ jobs:
     - name: Prepare To Install
       uses: actions/setup-node@v3
       with:
-        node-version: 12
+        node-version: 18
     - name: Install Deps
       run: |
         yarn install
@@ -89,7 +89,7 @@ jobs:
     - name: Prepare To Install
       uses: actions/setup-node@v3
       with:
-        node-version: 12
+        node-version: 18
     - name: Install Deps
       run: |
         yarn install

--- a/.github/workflows/build-onvif-video-broker-container.yml
+++ b/.github/workflows/build-onvif-video-broker-container.yml
@@ -54,7 +54,7 @@ jobs:
     - name: Prepare To Install
       uses: actions/setup-node@v3
       with:
-        node-version: 12
+        node-version: 18
     - name: Install Deps
       run: |
         yarn install
@@ -91,7 +91,7 @@ jobs:
     - name: Prepare To Install
       uses: actions/setup-node@v3
       with:
-        node-version: 12
+        node-version: 18
     - name: Install Deps
       run: |
         yarn install

--- a/.github/workflows/build-opcua-monitoring-broker-container.yml
+++ b/.github/workflows/build-opcua-monitoring-broker-container.yml
@@ -54,7 +54,7 @@ jobs:
     - name: Prepare To Install
       uses: actions/setup-node@v3
       with:
-        node-version: 12
+        node-version: 18
     - name: Install Deps
       run: |
         yarn install
@@ -89,7 +89,7 @@ jobs:
     - name: Prepare To Install
       uses: actions/setup-node@v3
       with:
-        node-version: 12
+        node-version: 18
     - name: Install Deps
       run: |
         yarn install

--- a/.github/workflows/build-video-streaming-app-container.yml
+++ b/.github/workflows/build-video-streaming-app-container.yml
@@ -54,7 +54,7 @@ jobs:
     - name: Prepare To Install
       uses: actions/setup-node@v3
       with:
-        node-version: 12
+        node-version: 18
     - name: Install Deps
       run: |
         yarn install
@@ -91,7 +91,7 @@ jobs:
     - name: Prepare To Install
       uses: actions/setup-node@v3
       with:
-        node-version: 12
+        node-version: 18
     - name: Install Deps
       run: |
         yarn install


### PR DESCRIPTION
<!--  Thank you for contributing to the Akri repo! Before submitting this PR, please make sure:
1. Read the Contributing Guide before submitting your PR: https://docs.akri.sh/community/contributing
2. Decide whether you need to add any labels to your PR, such as `same version` if the version should not be changed and your change will trigger the version check workflow. This will cause the workflow to automatically succeed: https://github.com/project-akri/akri/blob/main/.github/workflows/check-versioning.yml
3. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context. -->

**What this PR does / why we need it**:
Recently we started to hit errors when building application containers, the error is due to the version of node.js (12) is too old, update to version 18 to get rid of the errors.

**Special notes for your reviewer**:
There is another issue that Build Anomaly Detection App Container / per-arch (arm32v7) job takes forever to complete.  I'll address that in a separate PR.

**If applicable**:
- [ ] this PR has an associated PR with documentation in [akri-docs](https://github.com/project-akri/akri-docs)
- [ ] this PR contains unit tests
- [ ] added code adheres to standard Rust formatting (`cargo fmt`)
- [ ] code builds properly (`cargo build`)
- [ ] code is free of common mistakes (`cargo clippy`)
- [ ] all Akri tests succeed (`cargo test`)
- [ ] inline documentation builds (`cargo doc`)
- [ ] all commits pass the [DCO bot check](https://probot.github.io/apps/dco/) by being signed off -- see the failing DCO check for instructions on how to retroactively sign commits