### PR TITLE
fix typo in Agent build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![Check Rust](https://github.com/project-akri/akri/workflows/Check%20Rust/badge.svg?branch=main&event=push)](https://github.com/project-akri/akri/actions?query=workflow%3A%22Check+Rust%22)
 [![Tarpaulin Code Coverage](https://github.com/project-akri/akri/workflows/Tarpaulin%20Code%20Coverage/badge.svg?branch=main&event=push)](https://github.com/project-akri/akri/actions?query=workflow%3A%22Tarpaulin+Code+Coverage%22)
 [![Build Controller](https://github.com/project-akri/akri/workflows/Build%20Controller/badge.svg?branch=main&event=push)](https://github.com/project-akri/akri/actions?query=workflow%3A%22Build+Controller%22)
-[![Build Agent](https://github.com/project-akri/akri/workflows/Build%20Agent/badge.svg?branch=main&event=push)](https://github.com/project-akri/akri/actions?query=workflow%3A%22Build+Agents%22)
+[![Build Agent](https://github.com/project-akri/akri/workflows/Build%20Agents/badge.svg?branch=main&event=push)](https://github.com/project-akri/akri/actions?query=workflow%3A%22Build+Agents%22)
 [![Test K3s, Kubernetes, and MicroK8s](https://github.com/project-akri/akri/workflows/Test%20K3s,%20Kubernetes,%20and%20MicroK8s/badge.svg?branch=main&event=push)](https://github.com/project-akri/akri/actions?query=workflow%3A%22Test+K3s%2C+Kubernetes%2C+and+MicroK8s%22)
 
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![Check Rust](https://github.com/project-akri/akri/workflows/Check%20Rust/badge.svg?branch=main&event=push)](https://github.com/project-akri/akri/actions?query=workflow%3A%22Check+Rust%22)
 [![Tarpaulin Code Coverage](https://github.com/project-akri/akri/workflows/Tarpaulin%20Code%20Coverage/badge.svg?branch=main&event=push)](https://github.com/project-akri/akri/actions?query=workflow%3A%22Tarpaulin+Code+Coverage%22)
 [![Build Controller](https://github.com/project-akri/akri/workflows/Build%20Controller/badge.svg?branch=main&event=push)](https://github.com/project-akri/akri/actions?query=workflow%3A%22Build+Controller%22)
-[![Build Agent](https://github.com/project-akri/akri/workflows/Build%20Agent/badge.svg?branch=main&event=push)](https://github.com/project-akri/akri/actions?query=workflow%3A%22Build+Agent%22)
+[![Build Agent](https://github.com/project-akri/akri/workflows/Build%20Agent/badge.svg?branch=main&event=push)](https://github.com/project-akri/akri/actions?query=workflow%3A%22Build+Agents%22)
 [![Test K3s, Kubernetes, and MicroK8s](https://github.com/project-akri/akri/workflows/Test%20K3s,%20Kubernetes,%20and%20MicroK8s/badge.svg?branch=main&event=push)](https://github.com/project-akri/akri/actions?query=workflow%3A%22Test+K3s%2C+Kubernetes%2C+and+MicroK8s%22)
 
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 
 [![Check Rust](https://github.com/project-akri/akri/workflows/Check%20Rust/badge.svg?branch=main&event=push)](https://github.com/project-akri/akri/actions?query=workflow%3A%22Check+Rust%22)
 [![Tarpaulin Code Coverage](https://github.com/project-akri/akri/workflows/Tarpaulin%20Code%20Coverage/badge.svg?branch=main&event=push)](https://github.com/project-akri/akri/actions?query=workflow%3A%22Tarpaulin+Code+Coverage%22)
-[![Build Controller](https://github.com/project-akri/akri/workflows/Build%20Controller/badge.svg?branch=main&event=push)](https://github.com/project-akri/akri/actions?query=workflow%3A%22Build+Controller%22)
-[![Build Agent](https://github.com/project-akri/akri/workflows/Build%20Agents/badge.svg?branch=main&event=push)](https://github.com/project-akri/akri/actions?query=workflow%3A%22Build+Agents%22)
+[![Build Controller](https://github.com/project-akri/akri/workflows/Build%20Controller/badge.svg?branch=main&event=workflow_run)](https://github.com/project-akri/akri/actions?query=workflow%3A%22Build+Controller%22)
+[![Build Agent](https://github.com/project-akri/akri/workflows/Build%20Agents/badge.svg?branch=main&event=workflow_run)](https://github.com/project-akri/akri/actions?query=workflow%3A%22Build+Agents%22)
 [![Test K3s, Kubernetes, and MicroK8s](https://github.com/project-akri/akri/workflows/Test%20K3s,%20Kubernetes,%20and%20MicroK8s/badge.svg?branch=main&event=push)](https://github.com/project-akri/akri/actions?query=workflow%3A%22Test+K3s%2C+Kubernetes%2C+and+MicroK8s%22)
 
 


### PR DESCRIPTION
<!--  Thank you for contributing to the Akri repo! Before submitting this PR, please make sure:
1. Read the Contributing Guide before submitting your PR: https://docs.akri.sh/community/contributing
2. Decide whether you need to add any labels to your PR, such as `same version` if the version should not be changed and your change will trigger the version check workflow. This will cause the workflow to automatically succeed: https://github.com/project-akri/akri/blob/main/.github/workflows/check-versioning.yml
3. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context. -->

**What this PR does / why we need it**:
There is a typo in the README.md that causes broken link for Agent build.  Correct the typo to show correct link to Agent buildy.

the event type is wrong for Agent and Controller build badge, change to use correct event type to show correct result in badge.
**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR has an associated PR with documentation in [akri-docs](https://github.com/project-akri/akri-docs)
- [ ] this PR contains unit tests
- [ ] added code adheres to standard Rust formatting (`cargo fmt`)
- [ ] code builds properly (`cargo build`)
- [ ] code is free of common mistakes (`cargo clippy`)
- [ ] all Akri tests succeed (`cargo test`)
- [ ] inline documentation builds (`cargo doc`)
- [ ] all commits pass the [DCO bot check](https://probot.github.io/apps/dco/) by being signed off -- see the failing DCO check for instructions on how to retroactively sign commits