### PR TITLE
fix `brokerJob` specs to use `imagePullPolicy` and image `tag` from values.yaml

### DIFF
--- a/deployment/helm/templates/onvif-configuration.yaml
+++ b/deployment/helm/templates/onvif-configuration.yaml
@@ -139,12 +139,12 @@ spec:
         spec:
           containers:
           - name: {{ .Values.onvif.configuration.name }}-broker
-            image: {{ printf "%s:%s" .Values.onvif.configuration.brokerJob.image.repository .Values.onvif.configuration.brokerPod.image.tag | quote }}
+            image: {{ printf "%s:%s" .Values.onvif.configuration.brokerJob.image.repository .Values.onvif.configuration.brokerJob.image.tag | quote }}
             {{- if .Values.onvif.configuration.brokerJob.command }}
             command: 
               {{- toYaml .Values.onvif.configuration.brokerJob.command | nindent 14 }}
             {{- end }}
-            {{- with .Values.onvif.configuration.pullPolicy }}
+            {{- with .Values.onvif.configuration.brokerJob.image.pullPolicy }}
             imagePullPolicy: {{ . }}
             {{- end }}
             {{- if .Values.onvif.configuration.brokerJob.env }}

--- a/deployment/helm/templates/opcua-configuration.yaml
+++ b/deployment/helm/templates/opcua-configuration.yaml
@@ -106,12 +106,12 @@ spec:
         spec:
           containers:
           - name: {{ .Values.opcua.configuration.name }}-broker
-            image: {{ printf "%s:%s" .Values.opcua.configuration.brokerJob.image.repository .Values.opcua.configuration.brokerPod.image.tag | quote }}
+            image: {{ printf "%s:%s" .Values.opcua.configuration.brokerJob.image.repository .Values.opcua.configuration.brokerJob.image.tag | quote }}
             {{- if .Values.opcua.configuration.brokerJob.command }}
             command: 
               {{- toYaml .Values.opcua.configuration.brokerJob.command | nindent 14 }}
             {{- end }}
-            {{- with .Values.opcua.configuration.pullPolicy }}
+            {{- with .Values.opcua.configuration.brokerJob.image.pullPolicy }}
             imagePullPolicy: {{ . }}
             {{- end }}
             {{- if .Values.opcua.configuration.brokerJob.env }}

--- a/deployment/helm/templates/udev-configuration.yaml
+++ b/deployment/helm/templates/udev-configuration.yaml
@@ -72,12 +72,12 @@ spec:
         spec:
           containers:
           - name: {{ .Values.udev.configuration.name }}-broker
-            image: {{ printf "%s:%s" .Values.udev.configuration.brokerJob.image.repository .Values.udev.configuration.brokerPod.image.tag | quote }}
+            image: {{ printf "%s:%s" .Values.udev.configuration.brokerJob.image.repository .Values.udev.configuration.brokerJob.image.tag | quote }}
             {{- if .Values.udev.configuration.brokerJob.command }}
             command: 
               {{- toYaml .Values.udev.configuration.brokerJob.command | nindent 14 }}
             {{- end }}
-            {{- with .Values.udev.configuration.pullPolicy }}
+            {{- with .Values.udev.configuration.brokerJob.image.pullPolicy }}
             imagePullPolicy: {{ . }}
             {{- end }}
             resources:


### PR DESCRIPTION
<!--  Thank you for contributing to the Akri repo! Before submitting this PR, please make sure:
1. Read the Contributing Guide before submitting your PR: https://docs.akri.sh/community/contributing
2. Decide whether you need to add any labels to your PR, such as `same version` if the version should not be changed and your change will trigger the version check workflow. This will cause the workflow to automatically succeed: https://github.com/project-akri/akri/blob/main/.github/workflows/check-versioning.yml
3. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context. -->

**What this PR does / why we need it**:
Updates the three `brokerJob` specs to correctly use the  `pullPolicy` and image `tag` from the corresponding `brokerJob` section of values.yaml

closes #713 
closes #712 

**Special notes for your reviewer**:

**If applicable**:
- [n/a] this PR has an associated PR with documentation in [akri-docs](https://github.com/project-akri/akri-docs)
- [n/a ] this PR contains unit tests
- [n/a] added code adheres to standard Rust formatting (`cargo fmt`)
- [ ] code builds properly (`cargo build`)
- [ ] code is free of common mistakes (`cargo clippy`)
- [ ] all Akri tests succeed (`cargo test`)
- [ ] inline documentation builds (`cargo doc`)
- [x] all commits pass the [DCO bot check](https://probot.github.io/apps/dco/) by being signed off -- see the failing DCO check for instructions on how to retroactively sign commits