### PR TITLE
Add emeritus maintainers according to governance

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,5 @@
-# https://help.github.com/en/articles/about-code-owners#codeowners-syntax
+# This file is described here:  https://help.github.com/en/articles/about-code-owners
 
-*   @bfjelds @kate-goldenring @jiria @britel @romoh @adithyaj @johnsonshih @diconico07
+# Global Owners: These members are Core Maintainers of Akri
+* @kate-goldenring @yujinkim-msft @diconico07
+

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,0 @@
-# This file is described here:  https://help.github.com/en/articles/about-code-owners
-
-# Global Owners: These members are Core Maintainers of Akri
-* @kate-goldenring @bfjelds @romoh @jiria @adithyaj @johnsonshih @diconico07

--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,11 @@
+maintainers:
+- kate-goldenring
+- yujinkim-msft
+- diconico07
+
+emeritus:
+- bfjelds
+- jiria
+- romoh
+- adithyaj
+- johnsonshih


### PR DESCRIPTION
Akri's [Governance](https://github.com/project-akri/akri/blob/main/GOVERNANCE.md#emeritus-maintainers) states:

Akri has a list of emeritus maintainers for maintainers that have contributed to Akri in the past but are no longer actively maintaining the project. 
- If a **maintainer is no longer interested** or cannot perform the maintainer duties
listed above, they can volunteer to be moved to emeritus status. 
- If a **maintainer has not been involved in their maintainer duties for 6 months or longer**, they will automatically be moved to emeritus status. However, should they choose to become involved again, they can be moved back into the active maintainer status. 

This PR addresses the second bullet, moving inactive maintainers to emeritus status. Thank you for all of your contributions! You are always welcome to step back into the project and move back to maintainer status.

This PR also removes the [redundant CODEOWNERS](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-file-location) file. Now, `OWNERS` can be where we put governance roles and `.github/CODEOWNERS` will inform github who is a maintainer (to be tagged on PRs). To move yourself to emeritus, please update both of these files.