### PR TITLE
Move Kate Goldenring to Emeritus Maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # This file is described here:  https://help.github.com/en/articles/about-code-owners
 
 # Global Owners: These members are Core Maintainers of Akri
-* @kate-goldenring @yujinkim-msft @diconico07
+* @yujinkim-msft @diconico07
 

--- a/OWNERS
+++ b/OWNERS
@@ -1,5 +1,4 @@
 maintainers:
-- kate-goldenring
 - yujinkim-msft
 - diconico07
 
@@ -9,3 +8,4 @@ emeritus:
 - romoh
 - adithyaj
 - johnsonshih
+- kate-goldenring


### PR DESCRIPTION
I’ve decided to step away from my role as a maintainer of this project. Over the past four years, it has been an honor to work on this project and collaborate with such a talented community. Unfortunately, I can no longer commit the time needed to actively contribute. The project needs passionate maintainers to continue its development. If you are interested in stepping into this role, please reach out! I am happy to help with the transition process to aid the project’s success moving forward. You can find me in the CNCF and Kubernetes Slacks.