### PR TITLE
Bump upload-artifact GH action version

### DIFF
--- a/.github/workflows/run-helm.yml
+++ b/.github/workflows/run-helm.yml
@@ -90,7 +90,7 @@ jobs:
 
       - name: Upload new helm package as artifact
         if: (github.event_name == 'release') || (github.event_name == 'push' && github.ref == 'refs/heads/main') || (startsWith(github.event_name, 'pull_request') && github.event.action == 'closed' && github.event.pull_request.merged == true && github.ref != 'refs/heads/main')
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: charts
           path: /tmp/helm/repo
@@ -115,7 +115,7 @@ jobs:
 
       - name: Upload new merged helm chart index as artifact
         if: (github.event_name == 'release') || (github.event_name == 'push' && github.ref == 'refs/heads/main') || (startsWith(github.event_name, 'pull_request') && github.event.action == 'closed' && github.event.pull_request.merged == true && github.ref != 'refs/heads/main')
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: index
           path: index.yaml

--- a/.github/workflows/run-tarpaulin.yml
+++ b/.github/workflows/run-tarpaulin.yml
@@ -60,7 +60,7 @@ jobs:
         verbose: true
 
     - name: Archive code coverage results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: code-coverage-report
         path: cobertura.xml

--- a/.github/workflows/run-test-cases.yml
+++ b/.github/workflows/run-test-cases.yml
@@ -64,43 +64,43 @@ jobs:
 
       - name: Upload Agent container as artifact
         if: startsWith(github.event_name, 'pull_request')
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: agent.tar
           path: agent.tar
       - name: Upload Controller container as artifact
         if: startsWith(github.event_name, 'pull_request')
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: controller.tar
           path: controller.tar
       - name: Upload Webhook-Configuration container as artifact
         if: startsWith(github.event_name, 'pull_request')
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: webhook-configuration.tar
           path: webhook-configuration.tar
       - name: Upload DebugEcho discovery container as artifact
         if: startsWith(github.event_name, 'pull_request')
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: debug-echo-discovery.tar
           path: debug-echo-discovery.tar
       - name: Upload UDEV discovery container as artifact
         if: startsWith(github.event_name, 'pull_request')
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: udev-discovery.tar
           path: udev-discovery.tar
       - name: Upload ONVIF discovery container as artifact
         if: startsWith(github.event_name, 'pull_request')
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: onvif-discovery.tar
           path: onvif-discovery.tar
       - name: Upload OPCUA discovery container as artifact
         if: startsWith(github.event_name, 'pull_request')
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: opcua-discovery.tar
           path: opcua-discovery.tar
@@ -289,7 +289,7 @@ jobs:
 
       - name: Upload logs as artifact
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.sanitize-artifact-name.outputs.name }}
           path: /tmp/logs/


### PR DESCRIPTION

**What this PR does / why we need it**:
The PR is a quick fix to bump upload-artifact GH action to v4. I'll review other actions later.
closes #735

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR has an associated PR with documentation in [akri-docs](https://github.com/project-akri/akri-docs)
- [ ] this PR contains unit tests
- [ ] added code adheres to standard Rust formatting (`cargo fmt`)
- [ ] code builds properly (`cargo build`)
- [ ] code is free of common mistakes (`cargo clippy`)
- [ ] all Akri tests succeed (`cargo test`)
- [ ] inline documentation builds (`cargo doc`)
- [ ] all commits pass the [DCO bot check](https://probot.github.io/apps/dco/) by being signed off -- see the failing DCO check for instructions on how to retroactively sign commits