### PR TITLE
Optimize Dockerfile for Python demo app to reduce image size

### DIFF
--- a/build/containers/Dockerfile.python-app
+++ b/build/containers/Dockerfile.python-app
@@ -1,23 +1,31 @@
-ARG PYTHON_VERSION=3.9
-FROM python:${PYTHON_VERSION}-bookworm
+ARG PYTHON_VERSION=3.11
 
-# Avoid tzdata prompt 
+FROM python:${PYTHON_VERSION}-slim-bookworm
+
 ARG DEBIAN_FRONTEND=noninteractive
+
+
 RUN echo "Creating container based on debian:bullseye-slim for ${TARGETPLATFORM}" && \
-    apt-get update && \
-    apt-get install -y protobuf-compiler libprotoc-dev && \
-    apt-get clean
+   apt-get update && \
+   apt-get install -y --no-install-recommends \
+      protobuf-compiler \
+      libprotoc-dev && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/*
+
 
 WORKDIR /app
 
 ARG APPLICATION
+
 COPY ./samples/apps/${APPLICATION}/requirements.txt .
 
-RUN pip3 install --no-cache-dir -r ./requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 
 COPY ./samples/apps/${APPLICATION} .
 
-# Link the container to the Akri repository
-LABEL org.opencontainers.image.source https://github.com/project-akri/akri
+# OCI label
+LABEL org.opencontainers.image.source="https://github.com/project-akri/akri"
 
-CMD [ "python3", "./app.py" ]
+# Default command
+ENTRYPOINT [ "python3", "app.py" ]


### PR DESCRIPTION
<!--  Thank you for contributing to the Akri repo! Before submitting this PR, please make sure:
1. Read the Contributing Guide before submitting your PR: https://docs.akri.sh/community/contributing
2. Decide whether you need to add any labels to your PR, such as `same version` if the version should not be changed and your change will trigger the version check workflow. This will cause the workflow to automatically succeed: https://github.com/project-akri/akri/blob/main/.github/workflows/check-versioning.yml
3. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context. -->

**What this PR does / why we need it**:
This PR reduces the demo Application's Docker image size from approximately **1.2 GB to 255 MB** by switching to a slim base image and upgrading Python from **3.9 to 3.11**, resulting in improved security and performance. All dependencies continue to work as expected, with no version mismatches in the requirements.
