### PR TITLE
Update relevant GitHub Actions in CI workflows to latest versions

### DIFF
--- a/.github/workflows/auto-update-dependencies.yml
+++ b/.github/workflows/auto-update-dependencies.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
     - name: Checkout the head commit of the branch
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         persist-credentials: false 
         

--- a/.github/workflows/build-onvif-video-broker-container.yml
+++ b/.github/workflows/build-onvif-video-broker-container.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
     - name: Checkout the head commit of the branch
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         persist-credentials: false
 

--- a/.github/workflows/build-opcua-monitoring-broker-container.yml
+++ b/.github/workflows/build-opcua-monitoring-broker-container.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
     - name: Checkout the head commit of the branch
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         persist-credentials: false
 

--- a/.github/workflows/build-opencv-base-container.yml
+++ b/.github/workflows/build-opencv-base-container.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout the head commit of the branch
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         persist-credentials: false
 

--- a/.github/workflows/build-python-app-containers.yml
+++ b/.github/workflows/build-python-app-containers.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
     - name: Checkout the head commit of the branch
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         persist-credentials: false
 

--- a/.github/workflows/build-rust-containers.yml
+++ b/.github/workflows/build-rust-containers.yml
@@ -39,7 +39,7 @@ jobs:
     
     steps:
     - name: Checkout the head commit of the branch
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         persist-credentials: false
 

--- a/.github/workflows/check-rust.yml
+++ b/.github/workflows/check-rust.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
     - name: Checkout the head commit of the branch
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         persist-credentials: false
 

--- a/.github/workflows/check-versioning.yml
+++ b/.github/workflows/check-versioning.yml
@@ -55,7 +55,7 @@ jobs:
 
     steps:
     - name: Checkout the head commit of the branch
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         persist-credentials: false
 

--- a/.github/workflows/run-helm.yml
+++ b/.github/workflows/run-helm.yml
@@ -27,11 +27,11 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout the head commit of the branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 
-      - uses: azure/setup-helm@v3
+      - uses: azure/setup-helm@v4.3.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -46,11 +46,11 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout the head commit of the branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 
-      - uses: azure/setup-helm@v3
+      - uses: azure/setup-helm@v4.3.0
         with:
           version: "v3.4.0"
 
@@ -90,14 +90,14 @@ jobs:
 
       - name: Upload new helm package as artifact
         if: (github.event_name == 'release') || (github.event_name == 'push' && github.ref == 'refs/heads/main') || (startsWith(github.event_name, 'pull_request') && github.event.action == 'closed' && github.event.pull_request.merged == true && github.ref != 'refs/heads/main')
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: charts
           path: /tmp/helm/repo
 
       - name: Checkout gh-pages
         if: (github.event_name == 'release') || (github.event_name == 'push' && github.ref == 'refs/heads/main') || (startsWith(github.event_name, 'pull_request') && github.event.action == 'closed' && github.event.pull_request.merged == true && github.ref != 'refs/heads/main')
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: gh-pages
           persist-credentials: false
@@ -115,7 +115,7 @@ jobs:
 
       - name: Upload new merged helm chart index as artifact
         if: (github.event_name == 'release') || (github.event_name == 'push' && github.ref == 'refs/heads/main') || (startsWith(github.event_name, 'pull_request') && github.event.action == 'closed' && github.event.pull_request.merged == true && github.ref != 'refs/heads/main')
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: index
           path: index.yaml

--- a/.github/workflows/run-tarpaulin.yml
+++ b/.github/workflows/run-tarpaulin.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
     - name: Checkout the head commit of the branch
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         persist-credentials: false
 
@@ -53,14 +53,14 @@ jobs:
 
     - name: Upload report to codecov for push
       if: (!(startsWith(github.event_name, 'pull_request')))
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v5
       with:
         token: ${{secrets.CODECOV_TOKEN}}
         fail_ci_if_error: true
         verbose: true
 
     - name: Archive code coverage results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: code-coverage-report
         path: cobertura.xml

--- a/.github/workflows/run-test-cases.yml
+++ b/.github/workflows/run-test-cases.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - name: Checkout the head commit of the branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 
@@ -64,43 +64,43 @@ jobs:
 
       - name: Upload Agent container as artifact
         if: startsWith(github.event_name, 'pull_request')
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: agent.tar
           path: agent.tar
       - name: Upload Controller container as artifact
         if: startsWith(github.event_name, 'pull_request')
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: controller.tar
           path: controller.tar
       - name: Upload Webhook-Configuration container as artifact
         if: startsWith(github.event_name, 'pull_request')
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: webhook-configuration.tar
           path: webhook-configuration.tar
       - name: Upload DebugEcho discovery container as artifact
         if: startsWith(github.event_name, 'pull_request')
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: debug-echo-discovery.tar
           path: debug-echo-discovery.tar
       - name: Upload UDEV discovery container as artifact
         if: startsWith(github.event_name, 'pull_request')
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: udev-discovery.tar
           path: udev-discovery.tar
       - name: Upload ONVIF discovery container as artifact
         if: startsWith(github.event_name, 'pull_request')
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: onvif-discovery.tar
           path: onvif-discovery.tar
       - name: Upload OPCUA discovery container as artifact
         if: startsWith(github.event_name, 'pull_request')
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: opcua-discovery.tar
           path: opcua-discovery.tar
@@ -135,7 +135,7 @@ jobs:
 
     steps:
       - name: Checkout the head commit of the branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 
@@ -154,7 +154,7 @@ jobs:
 
       - name: Download container artifacts
         if: startsWith(github.event_name, 'pull_request')
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: /tmp/images
 
@@ -289,7 +289,7 @@ jobs:
 
       - name: Upload logs as artifact
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.sanitize-artifact-name.outputs.name }}
           path: /tmp/logs/

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -9,7 +9,7 @@ jobs:
   security_audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Run security audit check
         id: cargo-audit
         if: github.repository == 'project-akri/akri' # only run on main repo and not forks

--- a/.github/workflows/update-versions.yml
+++ b/.github/workflows/update-versions.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.issue.pull_request && contains(github.event.comment.body, '/add-same-version-label')
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Add same version label
       uses: actions/github-script@v6
       if: success()


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR updates old and deprecated GitHub Actions to their latest supported versions.

**Changes made:**
- Updated azure/setup-helm from v3 to v4.3.0
- Updated actions/checkout from v3 to v4
- Updated codecov/codecov-action from v3 to v5
- Updated actions/upload-artifact from v3 to v4
- Updated actions/download-artifact from v3 to v4

These updates help keep the CI workflows up to date.

**Special notes for your reviewer**:

- https://github.com/Azure/setup-helm (azure/setup-helm@v4.3.0)
- https://github.com/actions/checkout (actions/checkout@v4)
- https://github.com/codecov/codecov-action (codecov/codecov-action@v5)
- https://github.com/actions/upload-artifact (actions/upload-artifact@v4)
- https://github.com/actions/download-artifact ( actions/download-artifact@v4)

#736 
