### PR TITLE
fix imagePullPolicy reference for brokerPods

### DIFF
--- a/deployment/helm/templates/custom-configuration.yaml
+++ b/deployment/helm/templates/custom-configuration.yaml
@@ -16,7 +16,7 @@ spec:
       - name: {{ .Values.custom.configuration.name }}-broker
         image: {{ printf "%s:%s" .Values.custom.configuration.brokerPod.image.repository .Values.custom.configuration.brokerPod.image.tag | quote }}
         {{- with .Values.custom.configuration.pullPolicy }}
-        imagePullPolicy: {{ . }}
+        imagePullPolicy: {{ .Values.custom.configuration.brokerPod.image.pullPolicy }}
         {{- end }}
         {{- if .Values.custom.configuration.brokerPod.env }}
         env:


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes the imagePullPolicy in custom-configuration.yaml to correctly use the value from values.yaml. This makes sure the broker pod uses the pull policy set by the user.

#747 

