### PR TITLE
docs: add Philips to adopters list

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,9 +1,61 @@
 # Adopters
 
-If you are using Akri in your solutions, we would love to have your organization in our adopters list. This is a small contribution that helps the project gain momentum and support.
+This document lists the people and organizations that are using Akri in production or in a significant deployment capacity.
+Thank you to all that have adopted Akri and are willing to be listed as adopters!
 
-To add your organization to this list, feel free to PR the additions to this page, following [our contributor guide](https://docs.akri.sh/community/contributing). Alternatively, reach out to us on [Slack](http://aka.ms/akri/channel) if you have any questions or need help around this process.
+This is a small contribution that helps the project gain momentum and support.
 
 | **Organization** | **Reference or Description of Usage** |
 |------------------|---------------------------------------|
 | [Philips](https://www.philips.com) | Using Akri to dynamically discover and manage mice, keyboards, and USB storage devices at the edge. |
+
+## Adding Your Organization
+
+To add yourself or your organization, please send a pull request to this file.
+People and organizations are listed in alphabetical order.
+
+### Requirements
+
+- You must be using Akri in production or have a significant deployment
+- You must represent the listed person or organization
+- Information provided must be publicly shareable
+- A production deployment includes:
+  - Enterprise/company usage
+  - Cloud service provider offering
+  - Significant home lab/personal deployment
+
+### Template
+
+Use this template in the [Adopters List](#adopters-list) section:
+
+```markdown
+### Organization Name
+
+- **Description**: Brief description of your organization
+- **Usage**: How you use Akri (components, scale, etc.)
+- **Links**:
+  - [Website](https://example.com)
+  - [Docs](https://docs.example.com)
+- **Contacts**: (optional)
+  - GitHub: @username
+  - Kubernetes Slack: @slackhandle
+```
+
+## Notes
+
+- Organizations are listed alphabetically
+- Contact information is optional but encouraged for community building
+- Links should be publicly accessible
+- If you have questions about your deployment and this list, please reach out via the [Kubernetes Slack Akri Channel](https://kubernetes.slack.com/archives/C01D9L7QE8Z) or via [GitHub discussions](https://github.com/project-akri/akri/discussions/new/choose).
+
+## Adopters List
+
+### Philips
+
+- **Description**: 
+- **Usage**: Using Akri to dynamically discover and manage mice, keyboards, and USB storage devices at the edge.
+- **Links**:
+  - [Website](https://www.philips.com)
+- **Contacts**: 
+  - GitHub: @jackliu2024
+  - Kubernetes Slack: @jackliu

--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -5,8 +5,8 @@ Thank you to all that have adopted Akri and are willing to be listed as adopters
 
 This is a small contribution that helps the project gain momentum and support.
 
-| **Organization** | **Reference or Description of Usage** |
-|------------------|---------------------------------------|
+| **Organization**                   | **Reference or Description of Usage**                                                               |
+| ---------------------------------- | --------------------------------------------------------------------------------------------------- |
 | [Philips](https://www.philips.com) | Using Akri to dynamically discover and manage mice, keyboards, and USB storage devices at the edge. |
 
 ## Adding Your Organization
@@ -52,10 +52,13 @@ Use this template in the [Adopters List](#adopters-list) section:
 
 ### Philips
 
-- **Description**: 
+- **Description**: Loom is the IGT Ecosystem Platform — a non-medical software platform that orchestrates healthcare applications in hospital environments.
+  It integrates seamlessly with Philips interventional imaging systems and hospital IT infrastructure while maintaining strict data privacy boundaries.
 - **Usage**: Using Akri to dynamically discover and manage mice, keyboards, and USB storage devices at the edge.
 - **Links**:
   - [Website](https://www.philips.com)
-- **Contacts**: 
+  - Repository: Hosted under a private Philips internal organization and is not publicly accessible.
+- **Contacts**:
   - GitHub: @jackliu2024
   - Kubernetes Slack: @jackliu
+


### PR DESCRIPTION

**What this PR does / why we need it**:

- Adds a template for Akri adopters.
- Adds Philips to the adopters list.
