### PR TITLE
fix: accept YAML udev discoveryDetails in validating webhook

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4355,6 +4355,7 @@ dependencies = [
  "openapi",
  "openssl",
  "serde_json",
+ "serde_yaml",
 ]
 
 [[package]]

--- a/test/e2e/yaml/udevDevNullConfiguration.yaml
+++ b/test/e2e/yaml/udevDevNullConfiguration.yaml
@@ -3,6 +3,9 @@ kind: Configuration
 metadata:
   name: akri-udev-dev-null
 spec:
-  discoveryHandler: 
+  discoveryHandler:
     name: udev
-    discoveryDetails: '{"udevRules":["KERNEL==\"null\""],"permissions":"rwm"}'
+    discoveryDetails: |+
+      udevRules:
+        - KERNEL=="null"
+      permissions: rwm

--- a/test/e2e/yaml/udevGroupedConfiguration.yaml
+++ b/test/e2e/yaml/udevGroupedConfiguration.yaml
@@ -3,7 +3,10 @@ kind: Configuration
 metadata:
   name: akri-udev-grouped
 spec:
-  discoveryHandler: 
+  discoveryHandler:
     name: udev
-    discoveryDetails: '{{"groupRecursive":true,"udevRules":["ENV{{ID_PATH}}==\"{}\""],"permissions":"rwm"}}'
-    # discoveryDetails: '{"udevRules":["ENV{{ID_PATH}}==\"{}\""],"permissions":"rwm"}'
+    discoveryDetails: |+
+      groupRecursive: true
+      udevRules:
+        - ENV{{ID_PATH}}=="{}"
+      permissions: rwm

--- a/webhooks/validating/configuration/Cargo.toml
+++ b/webhooks/validating/configuration/Cargo.toml
@@ -17,6 +17,7 @@ k8s-openapi = { version = "0.22.0", default-features = false, features = ["schem
 openapi = { git = "https://github.com/DazWilkin/openapi-admission-v1", tag = "v1.1.0" }
 openssl = "0.10"
 serde_json = "1.0.61"
+serde_yaml = "0.9"
 
 [dev-dependencies]
 actix-rt = "2.2.0"

--- a/webhooks/validating/configuration/src/main.rs
+++ b/webhooks/validating/configuration/src/main.rs
@@ -2,7 +2,7 @@ use actix_web::{App, HttpResponse, HttpServer, Responder, post, web};
 use akri_shared::akri::configuration::Configuration;
 use akri_udev::discovery_handler::UdevDiscoveryDetails;
 use clap::Arg;
-use k8s_openapi::{apimachinery::pkg::runtime::RawExtension, serde::de::Error};
+use k8s_openapi::apimachinery::pkg::runtime::RawExtension;
 use openapi::models::{
     V1AdmissionRequest as AdmissionRequest, V1AdmissionResponse as AdmissionResponse,
     V1AdmissionReview as AdmissionReview, V1Status as Status,
@@ -190,7 +190,7 @@ fn validate_configuration(rqst: &AdmissionRequest) -> AdmissionResponse {
     }
 }
 
-fn validate_udev_discovery_details(config: &Configuration) -> Result<(), serde_json::Error> {
+fn validate_udev_discovery_details(config: &Configuration) -> Result<(), String> {
     match &config.spec.discovery_handler.discovery_details {
         details if details.is_empty() => {
             println!("Discovery details are empty");
@@ -204,7 +204,7 @@ fn validate_udev_discovery_details(config: &Configuration) -> Result<(), serde_j
             }
 
             // Try to parse the discovery details as UdevDiscoveryDetails
-            match serde_json::from_str::<UdevDiscoveryDetails>(details) {
+            match serde_yaml::from_str::<UdevDiscoveryDetails>(details) {
                 Ok(_) => {
                     // The UdevDiscoveryDetails struct already has a custom deserializer for permissions
                     // If we got here, that means the JSON was parsed successfully and permissions were validated
@@ -214,9 +214,7 @@ fn validate_udev_discovery_details(config: &Configuration) -> Result<(), serde_j
                     println!("Error parsing UdevDiscoveryDetails: {e}");
                     println!("JSON was: {details}");
                     // Return a proper error message when parsing fails
-                    Err(serde_json::Error::custom(format!(
-                        "Could not parse as Udev DiscoveryDetails: {e}"
-                    )))
+                    Err(format!("Could not parse as Udev DiscoveryDetails: {e}"))
                 }
             }
         }
@@ -1314,8 +1312,10 @@ mod tests {
         let result = validate_udev_discovery_details(&config);
         assert!(result.is_err());
         let error_message = result.unwrap_err().to_string();
-        assert!(error_message.starts_with("Could not parse as Udev DiscoveryDetails:"));
-        assert!(error_message.contains("expected"));
+        assert_eq!(
+            error_message,
+            "Could not parse as Udev DiscoveryDetails: missing field `udevRules`"
+        );
     }
 
     fn run_validate_configuration_discovery_properties(


### PR DESCRIPTION
**What this PR does / why we need it**:

The udev discoveryDetails are YAML in the Helm templates, sample configurations, and runtime discovery parser, but the validating webhook was parsing them as JSON. That caused valid demo and chart-generated udev configurations to be rejected when the webhook was enabled.

Switch the webhook validation path to YAML parsing and restore the udev e2e fixtures to YAML so validation, tests, and shipped examples all use the same format.

Fixes:

* #753

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR has an associated PR with documentation in [akri-docs](https://github.com/project-akri/akri-docs)
- [ ] this PR contains unit tests
- [x] added code adheres to standard Rust formatting (`cargo fmt`)
- [x] code builds properly (`cargo build`)
- [x] code is free of common mistakes (`cargo clippy`)
- [x] all Akri tests succeed (`cargo test`)
- [x] inline documentation builds (`cargo doc`)
- [x] all commits pass the [DCO bot check](https://probot.github.io/apps/dco/) by being signed off -- see the failing DCO check for instructions on how to retroactively sign commits