### PR TITLE
chore: add crds category - 'all'

### DIFF
--- a/shared/src/akri/configuration.rs
+++ b/shared/src/akri/configuration.rs
@@ -103,7 +103,13 @@ pub enum BrokerSpec {
 /// is created.
 #[derive(CustomResource, Serialize, Deserialize, Clone, Debug, JsonSchema)]
 // group = API_NAMESPACE and version = API_VERSION
-#[kube(group = "akri.sh", version = "v0", kind = "Configuration", namespaced)]
+#[kube(
+    group = "akri.sh",
+    version = "v0",
+    kind = "Configuration",
+    namespaced,
+    category = "all"
+)]
 #[serde(rename_all = "camelCase")]
 pub struct ConfigurationSpec {
     /// This defines the `DiscoveryHandler` that should be used to

--- a/shared/src/akri/instance.rs
+++ b/shared/src/akri/instance.rs
@@ -25,6 +25,7 @@ pub type InstanceList = ObjectList<Instance>;
     kind = "Instance",
     namespaced,
     shortname = "akrii",
+    category = "all",
     printcolumn = r#"{
         "name": "Config",
         "type": "string",


### PR DESCRIPTION
**What this PR does / why we need it**:

Both `akri-instance-crd.yaml` and `akri-configuration-crd.yaml` list `categories: [all]` (added directly to the YAML in #800 so the CRDs show up in `kubectl get all`).

Until now the source-side `#[kube(...)]` derives didn't declare the category, which meant `cargo run --bin gen_crds` produced an Instance CRD with `categories: []` — surfaced during the kube-rs 1.0 bump review (#815).

This change declares `category = "all"` on the derive macro for both `Instance` and `Configuration`, so the Rust source is now authoritative for CRD-level metadata.

`Configuration` is hand-maintained, so the derive change there has no immediate effect on the committed YAML. As such, this is a preemptive consistency fix for any future generator that picks up `Configuration`.


```sh
akri on  main via 🐍 v3.14.2 via 🦀 v1.88.0 
❯ diff <(cargo run -q --bin gen_crds 2>/dev/null | yq -y -S .) <(yq -y -S . deployment/helm/crds/akri-instance-crd.yaml)
8c8,9
<     categories: []
---
>     categories:
>       - all

akri on  crd-all-category via 🐍 v3.14.2 via 🦀 v1.88.0 
❯ diff <(cargo run -q --bin gen_crds 2>/dev/null | yq -y -S .) <(yq -y -S . deployment/helm/crds/akri-instance-crd.yaml)

(no diff)
```

**If applicable**:
- [ ] this PR has an associated PR with documentation in [akri-docs](https://github.com/project-akri/akri-docs)
- [ ] this PR contains unit tests
- [x] added code adheres to standard Rust formatting (`cargo fmt`)
- [x] code builds properly (`cargo build`)
- [x] code is free of common mistakes (`cargo clippy`)
- [x] all Akri tests succeed (`cargo test`)
- [ ] inline documentation builds (`cargo doc`)
- [x] all commits pass the [DCO bot check](https://probot.github.io/apps/dco/) by being signed off -- see the failing DCO check for instructions on how to retroactively sign commits