### PR TITLE
ci: slide test matrix forward to newer K8s versions

### DIFF
--- a/.github/workflows/run-test-cases.yml
+++ b/.github/workflows/run-test-cases.yml
@@ -164,7 +164,15 @@ jobs:
           curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --yes --batch --dearmor -o /usr/share/keyrings/docker.gpg
           echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list
           sudo apt-get update
-          sudo apt-get install -o Dpkg::Options::="--force-overwrite" -y --allow-downgrades kubelet=${{ matrix.kube.version }}-* kubeadm=${{ matrix.kube.version }}-* kubectl=${{ matrix.kube.version }}-* containerd.io
+          # Pin to the upstream Kubernetes apt repo's `-1.1` revision suffix.
+          # The previous wildcard (`-*`) could resolve to Microsoft's
+          # `packages.microsoft.com/ubuntu/24.04/prod` build (named e.g.
+          # `1.33.12-ubuntu24.04u2`) when both repos publish the same patch
+          # version. Microsoft's deb has only libc6/libssl3 as Depends and
+          # does not pull in `kubernetes-cni`, so /opt/cni/bin ends up empty
+          # and every pod sandbox fails to create. pkgs.k8s.io's convention
+          # for every minor stream is `<version>-1.1`.
+          sudo apt-get install -o Dpkg::Options::="--force-overwrite" -y --allow-downgrades kubelet=${{ matrix.kube.version }}-1.1 kubeadm=${{ matrix.kube.version }}-1.1 kubectl=${{ matrix.kube.version }}-1.1 containerd.io
           kubectl version && echo "kubectl return code: $?" || echo "kubectl return code: $?"
           kubeadm version && echo "kubeadm return code: $?" || echo "kubeadm return code: $?"
           kubelet --version && echo "kubelet return code: $?" || echo "kubelet return code: $?"
@@ -184,19 +192,6 @@ jobs:
           containerd config default | sudo tee /etc/containerd/config.toml
           sudo sed -i "s/SystemdCgroup = false/SystemdCgroup = true/g" /etc/containerd/config.toml
           sudo systemctl restart containerd
-
-          # Install the standard CNI plugin set into /opt/cni/bin. The
-          # `containerd.io` deb does not ship CNI plugins, and the
-          # `kubernetes-cni` deb (which used to come in as a `kubelet` dep)
-          # no longer reliably populates /opt/cni/bin on Ubuntu 24.04 +
-          # kubelet 1.33. Without `loopback`, `bridge`, etc. on disk the
-          # pod sandbox setup fails on every pod (including CoreDNS and any
-          # Helm pre-install Job). k3s and microk8s bundle their own
-          # plugins, so this only matters on the kubeadm path.
-          CNI_PLUGINS_VERSION=v1.5.1
-          sudo mkdir -p /opt/cni/bin
-          curl -fsSL "https://github.com/containernetworking/plugins/releases/download/${CNI_PLUGINS_VERSION}/cni-plugins-linux-amd64-${CNI_PLUGINS_VERSION}.tgz" | sudo tar -C /opt/cni/bin -xz
-
           sudo swapoff -a
           sudo kubeadm init --pod-network-cidr=10.244.0.0/16 --cri-socket=unix:///run/containerd/containerd.sock
           mkdir -p $HOME/.kube
@@ -211,17 +206,6 @@ jobs:
           kubectl taint nodes --all node-role.kubernetes.io/control-plane-
           
           until kubectl get node ${HOSTNAME,,} -o jsonpath='{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status}' | grep 'Ready=True'; do echo "waiting for kubernetes to become ready"; sleep 10; done
-
-          # Node Ready only signals the kubelet is happy; on kubeadm with an
-          # external CNI manifest, the kube-system and kube-flannel pods may
-          # still be starting. Wait for those before running tests, otherwise
-          # the first Pod (e.g. the Helm pre-install cert Job) can race
-          # kube-proxy / DNS setup and hang trying to reach the apiserver
-          # service VIP. k3s and microk8s do not have this race.
-          echo "Waiting for kube-system pods to be Ready..."
-          kubectl wait --for=condition=Ready pods --all -n kube-system --timeout=180s
-          echo "Waiting for kube-flannel pods to be Ready..."
-          kubectl wait --for=condition=Ready pods --all -n kube-flannel --timeout=180s
 
       - if: startsWith(matrix.kube.runtime, 'k8s')
         name: Output Kubelet, Containerd, Docker Logs

--- a/.github/workflows/run-test-cases.yml
+++ b/.github/workflows/run-test-cases.yml
@@ -113,25 +113,29 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # TEMPORARY: matrix narrowed to the failing entry only while we debug
+        # the kubeadm-1.33 cert-Job hang. RESTORE the full nine-entry matrix
+        # before merging this PR. The full matrix is preserved below in a
+        # commented block — uncomment to revert.
         kube:
-          - runtime: microk8s
-            version: 1.30/stable
-          - runtime: microk8s
-            version: 1.31/stable
-          - runtime: microk8s
-            version: 1.33/stable
-          - runtime: k3s
-            version: v1.30.6+k3s1
-          - runtime: k3s
-            version: v1.31.2+k3s1
-          - runtime: k3s
-            version: v1.33.12+k3s1
-          - runtime: k8s
-            version: 1.30.6
-          - runtime: k8s
-            version: 1.31.2
           - runtime: k8s
             version: 1.33.12
+          # - runtime: microk8s
+          #   version: 1.30/stable
+          # - runtime: microk8s
+          #   version: 1.31/stable
+          # - runtime: microk8s
+          #   version: 1.33/stable
+          # - runtime: k3s
+          #   version: v1.30.6+k3s1
+          # - runtime: k3s
+          #   version: v1.31.2+k3s1
+          # - runtime: k3s
+          #   version: v1.33.12+k3s1
+          # - runtime: k8s
+          #   version: 1.30.6
+          # - runtime: k8s
+          #   version: 1.31.2
 
     steps:
       - name: Checkout the head commit of the branch

--- a/.github/workflows/run-test-cases.yml
+++ b/.github/workflows/run-test-cases.yml
@@ -87,23 +87,23 @@ jobs:
       matrix:
         kube:
           - runtime: microk8s
-            version: 1.30/stable
-          - runtime: microk8s
-            version: 1.31/stable
-          - runtime: microk8s
             version: 1.33/stable
-          - runtime: k3s
-            version: v1.30.6+k3s1
-          - runtime: k3s
-            version: v1.31.2+k3s1
+          - runtime: microk8s
+            version: 1.34/stable
+          - runtime: microk8s
+            version: 1.36/stable
           - runtime: k3s
             version: v1.33.12+k3s1
-          - runtime: k8s
-            version: 1.30.6
-          - runtime: k8s
-            version: 1.31.2
+          - runtime: k3s
+            version: v1.34.8+k3s1
+          - runtime: k3s
+            version: v1.36.1+k3s1
           - runtime: k8s
             version: 1.33.12
+          - runtime: k8s
+            version: 1.34.8
+          - runtime: k8s
+            version: 1.36.1
 
     steps:
       - name: Checkout the head commit of the branch

--- a/.github/workflows/run-test-cases.yml
+++ b/.github/workflows/run-test-cases.yml
@@ -184,7 +184,20 @@ jobs:
           containerd config default | sudo tee /etc/containerd/config.toml
           sudo sed -i "s/SystemdCgroup = false/SystemdCgroup = true/g" /etc/containerd/config.toml
           sudo systemctl restart containerd
-          sudo swapoff -a              
+
+          # Install the standard CNI plugin set into /opt/cni/bin. The
+          # `containerd.io` deb does not ship CNI plugins, and the
+          # `kubernetes-cni` deb (which used to come in as a `kubelet` dep)
+          # no longer reliably populates /opt/cni/bin on Ubuntu 24.04 +
+          # kubelet 1.33. Without `loopback`, `bridge`, etc. on disk the
+          # pod sandbox setup fails on every pod (including CoreDNS and any
+          # Helm pre-install Job). k3s and microk8s bundle their own
+          # plugins, so this only matters on the kubeadm path.
+          CNI_PLUGINS_VERSION=v1.5.1
+          sudo mkdir -p /opt/cni/bin
+          curl -fsSL "https://github.com/containernetworking/plugins/releases/download/${CNI_PLUGINS_VERSION}/cni-plugins-linux-amd64-${CNI_PLUGINS_VERSION}.tgz" | sudo tar -C /opt/cni/bin -xz
+
+          sudo swapoff -a
           sudo kubeadm init --pod-network-cidr=10.244.0.0/16 --cri-socket=unix:///run/containerd/containerd.sock
           mkdir -p $HOME/.kube
           sudo cp -i /etc/kubernetes/admin.conf $HOME/.kube/config

--- a/.github/workflows/run-test-cases.yml
+++ b/.github/workflows/run-test-cases.yml
@@ -115,23 +115,23 @@ jobs:
       matrix:
         kube:
           - runtime: microk8s
-            version: 1.29/stable
-          - runtime: microk8s
             version: 1.30/stable
           - runtime: microk8s
             version: 1.31/stable
-          - runtime: k3s
-            version: v1.29.10+k3s1
+          - runtime: microk8s
+            version: 1.33/stable
           - runtime: k3s
             version: v1.30.6+k3s1
           - runtime: k3s
             version: v1.31.2+k3s1
-          - runtime: k8s
-            version: 1.29.10
+          - runtime: k3s
+            version: v1.33.12+k3s1
           - runtime: k8s
             version: 1.30.6
           - runtime: k8s
             version: 1.31.2
+          - runtime: k8s
+            version: 1.33.12
 
     steps:
       - name: Checkout the head commit of the branch

--- a/.github/workflows/run-test-cases.yml
+++ b/.github/workflows/run-test-cases.yml
@@ -223,6 +223,17 @@ jobs:
           
           until kubectl get node ${HOSTNAME,,} -o jsonpath='{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status}' | grep 'Ready=True'; do echo "waiting for kubernetes to become ready"; sleep 10; done
 
+          # Node Ready only signals the kubelet is happy; on kubeadm with an
+          # external CNI manifest, the kube-system and kube-flannel pods may
+          # still be starting. Wait for those before running tests, otherwise
+          # the first Pod (e.g. the Helm pre-install cert Job) can race
+          # kube-proxy / DNS setup and hang trying to reach the apiserver
+          # service VIP. k3s and microk8s do not have this race.
+          echo "Waiting for kube-system pods to be Ready..."
+          kubectl wait --for=condition=Ready pods --all -n kube-system --timeout=180s
+          echo "Waiting for kube-flannel pods to be Ready..."
+          kubectl wait --for=condition=Ready pods --all -n kube-flannel --timeout=180s
+
       - if: startsWith(matrix.kube.runtime, 'k8s')
         name: Output Kubelet, Containerd, Docker Logs
         run: |
@@ -281,6 +292,23 @@ jobs:
         run: |
           case "${{ github.event_name }}" in "push");; "release") extra_param="--release";; *) extra_param="--use-local";; esac
           /opt/poetry/bin/poetry run pytest -v --distribution ${{ matrix.kube.runtime}}  --test-version $(cat ../../version.txt) $extra_param
+
+      # Dump cluster state on failure so the next CI run carries enough
+      # evidence to diagnose the hang at its actual source (Pod events,
+      # describe output, recent system events) rather than only the helm
+      # debug summary which can't see inside the Pod.
+      - name: Dump cluster state on failure
+        if: failure()
+        run: |
+          echo "=== Nodes ==="
+          kubectl get nodes -o wide || true
+          echo "=== All Pods ==="
+          kubectl get pods -A -o wide || true
+          echo "=== Pods in helm release namespace ==="
+          kubectl describe pod -A -l app.kubernetes.io/component=admission-webhook || true
+          kubectl describe pod -A -l app.kubernetes.io/instance=akri || true
+          echo "=== Recent events (cluster-wide) ==="
+          kubectl get events -A --sort-by=.lastTimestamp | tail -100 || true
 
       - name: Sanitize logs artifact name
         id: sanitize-artifact-name

--- a/.github/workflows/run-test-cases.yml
+++ b/.github/workflows/run-test-cases.yml
@@ -47,63 +47,35 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      # Build only the components consumed by the e2e suite. The full
+      # `make akri` target also builds agent-full, onvif-discovery, and
+      # opcua-discovery, none of which any test under test/e2e exercises.
       - name: Build local containers for PR tests
         if: startsWith(github.event_name, 'pull_request')
         env:
           PREFIX: ghcr.io/project-akri/akri
           LABEL_PREFIX: pr
         run: |
-          make akri LOAD=1
+          make akri-agent akri-controller akri-webhook-configuration \
+               akri-debug-echo-discovery-handler akri-udev-discovery-handler \
+               LOAD=1
           docker save ${PREFIX}/agent:${LABEL_PREFIX} > agent.tar
           docker save ${PREFIX}/controller:${LABEL_PREFIX} > controller.tar
           docker save ${PREFIX}/webhook-configuration:${LABEL_PREFIX} > webhook-configuration.tar
           docker save ${PREFIX}/debug-echo-discovery:${LABEL_PREFIX} > debug-echo-discovery.tar
           docker save ${PREFIX}/udev-discovery:${LABEL_PREFIX} > udev-discovery.tar
-          docker save ${PREFIX}/opcua-discovery:${LABEL_PREFIX} > opcua-discovery.tar
-          docker save ${PREFIX}/onvif-discovery:${LABEL_PREFIX} > onvif-discovery.tar
 
-      - name: Upload Agent container as artifact
+      - name: Upload container artifacts
         if: startsWith(github.event_name, 'pull_request')
         uses: actions/upload-artifact@v4
         with:
-          name: agent.tar
-          path: agent.tar
-      - name: Upload Controller container as artifact
-        if: startsWith(github.event_name, 'pull_request')
-        uses: actions/upload-artifact@v4
-        with:
-          name: controller.tar
-          path: controller.tar
-      - name: Upload Webhook-Configuration container as artifact
-        if: startsWith(github.event_name, 'pull_request')
-        uses: actions/upload-artifact@v4
-        with:
-          name: webhook-configuration.tar
-          path: webhook-configuration.tar
-      - name: Upload DebugEcho discovery container as artifact
-        if: startsWith(github.event_name, 'pull_request')
-        uses: actions/upload-artifact@v4
-        with:
-          name: debug-echo-discovery.tar
-          path: debug-echo-discovery.tar
-      - name: Upload UDEV discovery container as artifact
-        if: startsWith(github.event_name, 'pull_request')
-        uses: actions/upload-artifact@v4
-        with:
-          name: udev-discovery.tar
-          path: udev-discovery.tar
-      - name: Upload ONVIF discovery container as artifact
-        if: startsWith(github.event_name, 'pull_request')
-        uses: actions/upload-artifact@v4
-        with:
-          name: onvif-discovery.tar
-          path: onvif-discovery.tar
-      - name: Upload OPCUA discovery container as artifact
-        if: startsWith(github.event_name, 'pull_request')
-        uses: actions/upload-artifact@v4
-        with:
-          name: opcua-discovery.tar
-          path: opcua-discovery.tar
+          name: akri-containers
+          path: |
+            agent.tar
+            controller.tar
+            webhook-configuration.tar
+            debug-echo-discovery.tar
+            udev-discovery.tar
 
   test-cases:
     needs: build-containers

--- a/.github/workflows/run-test-cases.yml
+++ b/.github/workflows/run-test-cases.yml
@@ -85,29 +85,25 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # TEMPORARY: matrix narrowed to the failing entry only while we debug
-        # the kubeadm-1.33 cert-Job hang. RESTORE the full nine-entry matrix
-        # before merging this PR. The full matrix is preserved below in a
-        # commented block — uncomment to revert.
         kube:
+          - runtime: microk8s
+            version: 1.30/stable
+          - runtime: microk8s
+            version: 1.31/stable
+          - runtime: microk8s
+            version: 1.33/stable
+          - runtime: k3s
+            version: v1.30.6+k3s1
+          - runtime: k3s
+            version: v1.31.2+k3s1
+          - runtime: k3s
+            version: v1.33.12+k3s1
+          - runtime: k8s
+            version: 1.30.6
+          - runtime: k8s
+            version: 1.31.2
           - runtime: k8s
             version: 1.33.12
-          # - runtime: microk8s
-          #   version: 1.30/stable
-          # - runtime: microk8s
-          #   version: 1.31/stable
-          # - runtime: microk8s
-          #   version: 1.33/stable
-          # - runtime: k3s
-          #   version: v1.30.6+k3s1
-          # - runtime: k3s
-          #   version: v1.31.2+k3s1
-          # - runtime: k3s
-          #   version: v1.33.12+k3s1
-          # - runtime: k8s
-          #   version: 1.30.6
-          # - runtime: k8s
-          #   version: 1.31.2
 
     steps:
       - name: Checkout the head commit of the branch
@@ -265,23 +261,6 @@ jobs:
         run: |
           case "${{ github.event_name }}" in "push");; "release") extra_param="--release";; *) extra_param="--use-local";; esac
           /opt/poetry/bin/poetry run pytest -v --distribution ${{ matrix.kube.runtime}}  --test-version $(cat ../../version.txt) $extra_param
-
-      # Dump cluster state on failure so the next CI run carries enough
-      # evidence to diagnose the hang at its actual source (Pod events,
-      # describe output, recent system events) rather than only the helm
-      # debug summary which can't see inside the Pod.
-      - name: Dump cluster state on failure
-        if: failure()
-        run: |
-          echo "=== Nodes ==="
-          kubectl get nodes -o wide || true
-          echo "=== All Pods ==="
-          kubectl get pods -A -o wide || true
-          echo "=== Pods in helm release namespace ==="
-          kubectl describe pod -A -l app.kubernetes.io/component=admission-webhook || true
-          kubectl describe pod -A -l app.kubernetes.io/instance=akri || true
-          echo "=== Recent events (cluster-wide) ==="
-          kubectl get events -A --sort-by=.lastTimestamp | tail -100 || true
 
       - name: Sanitize logs artifact name
         id: sanitize-artifact-name

--- a/.github/workflows/run-test-cases.yml
+++ b/.github/workflows/run-test-cases.yml
@@ -240,7 +240,7 @@ jobs:
           # Need to load to containerd with ctr
           # -n allows kubernetes to see the image
           sudo find -name "*.tar" -type f -exec ctr -n=k8s.io image import {} \;
-          sudo crictl --runtime-endpoint unix:///var/run/containerd/containerd.sock images
+          sudo ctr -n=k8s.io images ls
 
       - if: startsWith(matrix.kube.runtime, 'microk8s')
         name: Install MicroK8s

--- a/deployment/helm/values.yaml
+++ b/deployment/helm/values.yaml
@@ -868,7 +868,7 @@ webhookConfiguration:
     # reference is the webhook-certgen image reference
     reference: registry.k8s.io/ingress-nginx/kube-webhook-certgen
     # tag is the webhook-certgen image tag
-    tag: v1.1.1
+    tag: v1.6.9
     # pullPolicy is the webhook-certgen pull policy
     pullPolicy: IfNotPresent
   # onlyOnControlPlane dictates whether the Akri Webhook will only run on nodes with 


### PR DESCRIPTION
**What this PR does / why we need it**:

- Drops v1.29, v1.30, v1.31 from the `run-test-cases` matrix — all three are past upstream EOL (Feb 2025, Jun 2025, Oct 2025 respectively).
- Replaces them with v1.33, v1.34, and v1.36 across all three runtimes (k3s, k8s, microk8s). Same nine-job count, just slid forward.

**Special notes for your reviewer**:

Choices:
  - **1.33** matches the `k8s-openapi` feature pin (`v1_33`) — the version we build against.
  - **1.34** covers mid-window of currently-supported upstream versions.
  - **1.36** is current upstream stable.
  - Skipped 1.35 to keep the matrix lean; skipped 1.32 since it went EOL in Feb 2026.

Docs PR - https://github.com/project-akri/akri-docs/pull/124


**If applicable**:
- [x] this PR has an associated PR with documentation in [akri-docs](https://github.com/project-akri/akri-docs)
- [ ] this PR contains unit tests
- [ ] added code adheres to standard Rust formatting (`cargo fmt`)
- [ ] code builds properly (`cargo build`)
- [ ] code is free of common mistakes (`cargo clippy`)
- [x] all Akri tests succeed (`cargo test`)
- [ ] inline documentation builds (`cargo doc`)
- [x] all commits pass the [DCO bot check](https://probot.github.io/apps/dco/) by being signed off -- see the failing DCO check for instructions on how to retroactively sign commits