### PR TITLE
Fix update-versions workflow overwriting PR's version.sh

### DIFF
--- a/.github/workflows/update-versions.yml
+++ b/.github/workflows/update-versions.yml
@@ -59,10 +59,12 @@ jobs:
         ref: ${{ fromJSON(steps.get-pr.outputs.result).head.ref }}
 
     # Security: Checkout the trusted version.sh from main branch to prevent script injection
+    # Note: origin may point to a fork, so fetch from the upstream repo explicitly
     - name: Checkout version.sh from main branch
       run: |
-        git fetch origin main
-        git checkout origin/main -- version.sh
+        git remote add upstream https://github.com/${{ github.repository }}.git || true
+        git fetch upstream main
+        git checkout upstream/main -- version.sh
         chmod +x version.sh
 
     - name: Update version minor
@@ -100,6 +102,8 @@ jobs:
       run: |
         git config user.name 'github-actions[bot]'
         git config user.email 'github-actions[bot]@users.noreply.github.com'
+        # Restore the PR's version.sh so the security checkout doesn't get committed
+        git checkout HEAD -- version.sh
         git pull
         git add .
         git commit -m "Update ${{ env.BUMP_TYPE }} version" --signoff


### PR DESCRIPTION
Two bugs fixed:

1. Fetch version.sh from upstream repo instead of origin. When a PR comes from a fork, origin points to the fork, so 'git fetch origin main' fetches the fork's (potentially stale) main branch instead of the upstream repo's main. Use an explicit upstream remote to always get the correct version.sh.

2. Restore the PR's version.sh before committing. The security step overwrites version.sh with the copy from main, but 'git add .' stages that change and pushes it back into the PR branch, causing unintended modifications (typos, stale crate lists) to appear in the PR.

<!--  Thank you for contributing to the Akri repo! Before submitting this PR, please make sure:
1. Read the Contributing Guide before submitting your PR: https://docs.akri.sh/community/contributing
2. Decide whether you need to add any labels to your PR, such as `same version` if the version should not be changed and your change will trigger the version check workflow. This will cause the workflow to automatically succeed: https://github.com/project-akri/akri/blob/main/.github/workflows/check-versioning.yml
3. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context. -->

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR has an associated PR with documentation in [akri-docs](https://github.com/project-akri/akri-docs)
- [ ] this PR contains unit tests
- [ ] added code adheres to standard Rust formatting (`cargo fmt`)
- [ ] code builds properly (`cargo build`)
- [ ] code is free of common mistakes (`cargo clippy`)
- [ ] all Akri tests succeed (`cargo test`)
- [ ] inline documentation builds (`cargo doc`)
- [ ] all commits pass the [DCO bot check](https://probot.github.io/apps/dco/) by being signed off -- see the failing DCO check for instructions on how to retroactively sign commits