### PR TITLE
docs: remove Philips from adopters list

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -7,7 +7,6 @@ This is a small contribution that helps the project gain momentum and support.
 
 | **Organization**                   | **Reference or Description of Usage**                                                               |
 | ---------------------------------- | --------------------------------------------------------------------------------------------------- |
-| [Philips](https://www.philips.com) | Using Akri to dynamically discover and manage mice, keyboards, and USB storage devices at the edge. |
 
 ## Adding Your Organization
 
@@ -50,15 +49,4 @@ Use this template in the [Adopters List](#adopters-list) section:
 
 ## Adopters List
 
-### Philips
-
-- **Description**: Loom is the IGT Ecosystem Platform — a non-medical software platform that orchestrates healthcare applications in hospital environments.
-  It integrates seamlessly with Philips interventional imaging systems and hospital IT infrastructure while maintaining strict data privacy boundaries.
-- **Usage**: Using Akri to dynamically discover and manage mice, keyboards, and USB storage devices at the edge.
-- **Links**:
-  - [Website](https://www.philips.com)
-  - Repository: Hosted under a private Philips internal organization and is not publicly accessible.
-- **Contacts**:
-  - GitHub: @jackliu2024
-  - Kubernetes Slack: @jackliu
 


### PR DESCRIPTION
Removed Philips from the adopters list and its associated details.

<!--  Thank you for contributing to the Akri repo! Before submitting this PR, please make sure:
1. Read the Contributing Guide before submitting your PR: https://docs.akri.sh/community/contributing
2. Decide whether you need to add any labels to your PR, such as `same version` if the version should not be changed and your change will trigger the version check workflow. This will cause the workflow to automatically succeed: https://github.com/project-akri/akri/blob/main/.github/workflows/check-versioning.yml
3. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context. -->

**What this PR does / why we need it**:
Removed Philips from the ADOPTERS.md adopters table and the Adopters List section, as the entry was added prematurely before internal alignment on public-facing communications.

**Special notes for your reviewer**:
Hi @gauravgahlot, as discussed via email, please remove the Philips entry from ADOPTERS.md. We will add a proper public-facing statement once aligned internally. Thank you!

**If applicable**:
- [ ] this PR has an associated PR with documentation in [akri-docs](https://github.com/project-akri/akri-docs)
- [ ] this PR contains unit tests
- [ ] added code adheres to standard Rust formatting (`cargo fmt`)
- [ ] code builds properly (`cargo build`)
- [ ] code is free of common mistakes (`cargo clippy`)
- [ ] all Akri tests succeed (`cargo test`)
- [ ] inline documentation builds (`cargo doc`)
- [ ] all commits pass the [DCO bot check](https://probot.github.io/apps/dco/) by being signed off -- see the failing DCO check for instructions on how to retroactively sign commits