### PR TITLE
fix: RUSTSEC-2024-0437

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,7 +237,6 @@ dependencies = [
  "kube-runtime",
  "lazy_static",
  "log",
- "mock_instant",
  "mockall",
  "mockall_double",
  "prometheus",
@@ -2459,15 +2458,6 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "mock_instant"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "717e29a243b81f8130e31e24e04fb151b04a44b5a7d05370935f7d937e9de06d"
-dependencies = [
- "once_cell",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2949,22 +2949,21 @@ dependencies = [
 
 [[package]]
 name = "procfs"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "731e0d9356b0c25f16f33b5be79b1c57b562f141ebfcdb0ad8ac2c13a24293b4"
+checksum = "cc5b72d8145275d844d4b5f6d4e1eef00c8cd889edb6035c21675d1bb1f45c9f"
 dependencies = [
  "bitflags 2.13.0",
  "hex",
- "lazy_static",
  "procfs-core",
  "rustix 0.38.44",
 ]
 
 [[package]]
 name = "procfs-core"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d3554923a69f4ce04c4a754260c338f505ce22642d3830e049a399fc2059a29"
+checksum = "239df02d8349b06fc07398a3a1697b06418223b1c7725085e801e7c0fc6a12ec"
 dependencies = [
  "bitflags 2.13.0",
  "hex",
@@ -2972,9 +2971,9 @@ dependencies = [
 
 [[package]]
 name = "prometheus"
-version = "0.13.4"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d33c28a30771f7f96db69893f78b857f7450d7e0237e9c8fc6427a81bae7ed1"
+checksum = "3ca5326d8d0b950a9acd87e6a3f94745394f62e4dae1b1ee22b2bc0c394af43a"
 dependencies = [
  "cfg-if",
  "fnv",
@@ -2984,7 +2983,7 @@ dependencies = [
  "parking_lot",
  "procfs",
  "protobuf",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3041,9 +3040,23 @@ dependencies = [
 
 [[package]]
 name = "protobuf"
-version = "2.28.0"
+version = "3.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
+checksum = "d65a1d4ddae7d8b5de68153b48f6aa3bba8cb002b243dbdbc55a5afbc98f99f4"
+dependencies = [
+ "once_cell",
+ "protobuf-support",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "protobuf-support"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e36c2f31e0a47f9280fb347ef5e461ffcd2c52dd520d8e216b52f93b0b0d7d6"
+dependencies = [
+ "thiserror 1.0.69",
+]
 
 [[package]]
 name = "quick-error"

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -56,7 +56,6 @@ akri-onvif = { path = "../discovery-handlers/onvif" }
 akri-opcua = { path = "../discovery-handlers/opcua" }
 akri-udev = { path = "../discovery-handlers/udev"}
 env_logger = "0.11.8"
-mock_instant = { version = "0.2", features = ["sync"] }
 mockall = "0.12"
 serde_yaml = "0.9"
 tempfile = "3.1.0"

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -32,8 +32,8 @@ kube-runtime = { version = "1.0.0", features = ["unstable-runtime-reconcile-on"]
 lazy_static = "1.4"
 log = "0.4"
 mockall_double = "0.3.1"
-prometheus = { version = "0.13.4", features = ["process"] }
 prost = "0.13"
+prometheus = { version = "0.14.0", features = ["process"] }
 serde = "1.0.104"
 serde_derive = "1.0.104"
 serde_json = "1.0.45"

--- a/controller/Cargo.toml
+++ b/controller/Cargo.toml
@@ -19,7 +19,7 @@ k8s-openapi = { version = "0.25.0", default-features = false, features = ["schem
 kube = { version = "1.0.0", features = ["client", "derive", "runtime"] }
 lazy_static = "1.4"
 log = "0.4"
-prometheus = { version = "0.13.4", features = ["process"] }
+prometheus = { version = "0.14.0", features = ["process"] }
 tokio = { version = "1.0.2", features = ["full"] }
 
 [dev-dependencies]

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -17,7 +17,7 @@ k8s-openapi = { version = "0.25.0", default-features = false, features = ["schem
 kube = { version = "1.0.0",  features = ["derive" ] }
 log = "0.4"
 mockall = "0.12"
-prometheus = { version = "0.13.4", features = ["process"] }
+prometheus = { version = "0.14.0", features = ["process"] }
 rand = "0.8.3"
 schemars = "0.8.0"
 serde = "1.0"


### PR DESCRIPTION

**What this PR does / why we need it**:

Fixes: #805 

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR has an associated PR with documentation in [akri-docs](https://github.com/project-akri/akri-docs)
- [ ] this PR contains unit tests
- [x] added code adheres to standard Rust formatting (`cargo fmt`)
- [x] code builds properly (`cargo build`)
- [x] code is free of common mistakes (`cargo clippy`)
- [x] all Akri tests succeed (`cargo test`)
- [x] inline documentation builds (`cargo doc`)
- [x] all commits pass the [DCO bot check](https://probot.github.io/apps/dco/) by being signed off -- see the failing DCO check for instructions on how to retroactively sign commits