### PR TITLE
chore: update h2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1443,9 +1443,8 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+version = "0.4.15"
+source = "git+https://github.com/project-akri/h2?rev=e01e8842a37bc3590228e9ab408fc1710018c031#e01e8842a37bc3590228e9ab408fc1710018c031"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1667,7 +1666,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.14",
+ "h2 0.4.15",
  "http 1.4.2",
  "http-body 1.0.1",
  "httparse",
@@ -3754,7 +3753,7 @@ dependencies = [
  "axum",
  "base64 0.22.1",
  "bytes",
- "h2 0.4.14",
+ "h2 0.4.15",
  "http 1.4.2",
  "http-body 1.0.1",
  "http-body-util",
@@ -4741,8 +4740,3 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "h2"
-version = "0.4.15"
-source = "git+https://github.com/project-akri/h2?rev=e01e8842a37bc3590228e9ab408fc1710018c031#e01e8842a37bc3590228e9ab408fc1710018c031"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4744,5 +4744,5 @@ dependencies = [
 
 [[patch.unused]]
 name = "h2"
-version = "0.3.26"
-source = "git+https://github.com/project-akri/h2?branch=patch-authority#1bf9857fbc66d6898a68ac77070ffc95963b6c22"
+version = "0.4.15"
+source = "git+https://github.com/project-akri/h2?rev=e01e8842a37bc3590228e9ab408fc1710018c031#e01e8842a37bc3590228e9ab408fc1710018c031"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,9 @@
 [patch.crates-io]
 # Patch is still needed, using one from upstream PR for now, hosted on a fork of ours to help
 # with supply chain integrity.
-h2 = { git = 'https://github.com/project-akri/h2', branch = 'patch-authority'}
+# rev below is the tip of the `patch-authority` branch, pinned by commit so a future
+# `cargo update` can't silently move the patch (which is how it previously went stale).
+h2 = { git = 'https://github.com/project-akri/h2', rev = 'e01e8842a37bc3590228e9ab408fc1710018c031'}
 
 [workspace]
 members = [


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes: #686 

**Special notes for your reviewer**:

- The fork https://github.com/project-akri/h2 has been updated
- I rebased `patch-authority` on the latest `master` 
- Locally tested the update with `udev` example.

**If applicable**:
- [ ] this PR has an associated PR with documentation in [akri-docs](https://github.com/project-akri/akri-docs)
- [ ] this PR contains unit tests
- [ ] added code adheres to standard Rust formatting (`cargo fmt`)
- [x] code builds properly (`cargo build`)
- [x] code is free of common mistakes (`cargo clippy`)
- [x] all Akri tests succeed (`cargo test`)
- [x] inline documentation builds (`cargo doc`)
- [x] all commits pass the [DCO bot check](https://probot.github.io/apps/dco/) by being signed off -- see the failing DCO check for instructions on how to retroactively sign commits