### PR TITLE
docs: update community call time

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ To see what else is in store for Akri, reference our [roadmap](https://docs.akri
 
 ## Community, Contributing, and Support
 
-You can reach the Akri community via the [#akri](https://kubernetes.slack.com/messages/akri) channel in [Kubernetes Slack](https://kubernetes.slack.com) or join our [community calls](https://hackmd.io/@akri/S1GKJidJd) on the first Tuesday of the month at 9:00 AM PT.
+You can reach the Akri community via the [#akri](https://kubernetes.slack.com/messages/akri) channel in [Kubernetes Slack](https://kubernetes.slack.com) or join our [community calls](https://hackmd.io/@akri/S1GKJidJd) on the first Tuesday of the month from 8:00 AM to 9:00 AM PT.
 
 Akri welcomes contributions, whether by [creating new issues](https://github.com/project-akri/akri/issues/new/choose) or pull requests.
 See our [contributing document](https://docs.akri.sh/community/contributing) on how to get started!

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ To see what else is in store for Akri, reference our [roadmap](https://docs.akri
 
 ## Community, Contributing, and Support
 
-You can reach the Akri community via the [#akri](https://kubernetes.slack.com/messages/akri) channel in [Kubernetes Slack](https://kubernetes.slack.com) or join our [community calls](https://hackmd.io/@akri/S1GKJidJd) on the first Tuesday of the month from 8:00 AM to 9:00 AM PT.
+You can reach the Akri community via the [#akri](https://kubernetes.slack.com/messages/akri) channel in [Kubernetes Slack](https://kubernetes.slack.com) and/or join our [community calls](https://hackmd.io/@akri/S1GKJidJd) on the first Tuesday of the month from 8:00 AM to 9:00 AM PT.
 
 Akri welcomes contributions, whether by [creating new issues](https://github.com/project-akri/akri/issues/new/choose) or pull requests.
 See our [contributing document](https://docs.akri.sh/community/contributing) on how to get started!


### PR DESCRIPTION
What this PR does / why we need it:

Updates the Akri README community call time from 9:00 AM PT to 8:00 AM to 9:00 AM PT.

The linked Akri community meeting notes currently list the developer call as taking place from 8:00 AM to 9:00 AM, so this keeps the README consistent with the meeting page.

Special notes for your reviewer:

Docs-only README change. No code or behavior changes.

If applicable:

* this PR has an associated PR with documentation in [akri-docs](https://github.com/project-akri/akri-docs)
* this PR contains unit tests
* added code adheres to standard Rust formatting (cargo fmt)
* code builds properly (cargo build)
* code is free of common mistakes (cargo clippy)
* all Akri tests succeed (cargo test)
* inline documentation builds (cargo doc)
* all commits pass the [DCO bot check](https://probot.github.io/apps/dco/) by being signed off – see the failing DCO check for instructions on how to retroactively sign commits