### PR TITLE
test: verify broker properties update reconciliation

### DIFF
--- a/agent/src/util/discovery_configuration_controller.rs
+++ b/agent/src/util/discovery_configuration_controller.rs
@@ -15,14 +15,14 @@ use futures::StreamExt;
 use tokio::sync::mpsc;
 
 use crate::discovery_handler_manager::{
-    DiscoveryError, discovery_handler_registry::DiscoveryHandlerRegistry,
+    discovery_handler_registry::DiscoveryHandlerRegistry, DiscoveryError,
 };
 
 use kube::api::ObjectMeta;
 use kube::runtime::{
-    Controller,
     controller::Action,
     reflector::{ObjectRef, Store},
+    Controller,
 };
 use kube::{Resource, ResourceExt};
 use thiserror::Error;
@@ -490,6 +490,10 @@ mod tests {
         let mut request = MockDiscoveryHandlerRequest::new();
         request
             .expect_set_extra_device_properties()
+            .with(eq(HashMap::from([(
+                "BROKER_PROPERTY".to_string(),
+                "updated-value".to_string(),
+            )])))
             .returning(|_| {});
         request.expect_get_instances().returning(|| Ok(vec![]));
         registry
@@ -522,7 +526,10 @@ mod tests {
                 broker_spec: None,
                 instance_service_spec: None,
                 configuration_service_spec: None,
-                broker_properties: Default::default(),
+                broker_properties: HashMap::from([(
+                    "BROKER_PROPERTY".to_string(),
+                    "updated-value".to_string(),
+                )]),
             },
         });
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Strengthens the Agent reconciliation unit test for existing discovery requests.

Previously, `test_reconcile_nothing_to_do` only verified that `set_extra_device_properties()` was called. This update verifies that the method receives the broker properties from the updated `ConfigurationSpec`.

This helps cover the reconciliation path where an existing discovery request should receive updated broker properties from the Akri Configuration.

**Special notes for your reviewer**:

This is a test-only change. No production behavior is changed.

**Testing**:

- `rustfmt agent/src/util/discovery_configuration_controller.rs --edition 2021 --check`
- Attempted `cargo test -p agent test_reconcile_nothing_to_do`, but local macOS build is blocked by the Linux-only `libudev` system dependency.

**If applicable**:
- [ ] this PR has an associated PR with documentation in [akri-docs](https://github.com/project-akri/akri-docs)
- [x] this PR contains unit tests
- [x] added code adheres to standard Rust formatting (`rustfmt agent/src/util/discovery_configuration_controller.rs --edition 2021 --check`)
- [ ] code builds properly (`cargo build`)
- [ ] code is free of common mistakes (`cargo clippy`)
- [ ] all Akri tests succeed (`cargo test`)
- [ ] inline documentation builds (`cargo doc`)
- [x] all commits pass the [DCO bot check](https://probot.github.io/apps/dco/) by being signed off -- see the failing DCO check for instructions on how to retroactively sign commits