### PR TITLE
fix: update sample app image references

### DIFF
--- a/deployment/samples/akri-anomaly-detection-app.yaml
+++ b/deployment/samples/akri-anomaly-detection-app.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: akri-anomaly-detection-app
-        image: ghcr.io/project-akri/akri/anomaly-detection-app:latest-dev
+        image: ghcr.io/project-akri/examples/anomaly-detection-app:latest-dev
         imagePullPolicy: Always
         securityContext:
           runAsUser: 1000

--- a/deployment/samples/akri-video-streaming-app.yaml
+++ b/deployment/samples/akri-video-streaming-app.yaml
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: akri-video-streaming-app-sa
       containers:
       - name: akri-video-streaming-app
-        image: ghcr.io/project-akri/akri/video-streaming-app:latest-dev
+        image: ghcr.io/project-akri/examples/video-streaming-app:latest-dev
         imagePullPolicy: Always
         securityContext:
           runAsUser: 1000


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates the sample application manifests under `deployment/samples` to use the `project-akri/examples` image namespace.

The sample apps have moved to the `project-akri/examples` repository, and the examples repo workflows now publish app images under:

`ghcr.io/project-akri/examples/${component}`

This PR updates:

- `ghcr.io/project-akri/akri/video-streaming-app:latest-dev`
- `ghcr.io/project-akri/akri/anomaly-detection-app:latest-dev`

to:

- `ghcr.io/project-akri/examples/video-streaming-app:latest-dev`
- `ghcr.io/project-akri/examples/anomaly-detection-app:latest-dev`

This also supports the v0.14.0 release tracking item to audit Helm/sample image defaults after the examples repo migration.

**Special notes for your reviewer**:

This is a sample manifest update only. No production code changes.

**Testing**:

- Verified the updated image paths match the `project-akri/examples` image namespace used by the examples repo build workflows.
- Ran grep to confirm old sample app image references are no longer present in `deployment/samples`.

**If applicable**:
- [ ] this PR has an associated PR with documentation in [akri-docs](https://github.com/project-akri/akri-docs)
- [ ] this PR contains unit tests
- [ ] added code adheres to standard Rust formatting (`cargo fmt`)
- [ ] code builds properly (`cargo build`)
- [ ] code is free of common mistakes (`cargo clippy`)
- [ ] all Akri tests succeed (`cargo test`)
- [ ] inline documentation builds (`cargo doc`)
- [x] all commits pass the [DCO bot check](https://probot.github.io/apps/dco/) by being signed off -- see the failing DCO check for instructions on how to retroactively sign commits