### PR TITLE
fix: install protobuf-compiler in the dependency autoupdate workflow

### DIFF
--- a/.github/workflows/auto-update-dependencies.yml
+++ b/.github/workflows/auto-update-dependencies.yml
@@ -20,7 +20,7 @@ jobs:
         
     - name: Install Linux requirements
       run: |
-        apt_dependencies="git curl libssl-dev pkg-config libudev-dev libv4l-dev"
+        apt_dependencies="git curl libssl-dev pkg-config libudev-dev libv4l-dev protobuf-compiler"
         echo "Run apt update and apt install the following dependencies: $apt_dependencies"
         sudo apt update
         sudo apt install -y $apt_dependencies


### PR DESCRIPTION
`Dependencies autoupdate` has failed on the first of every month since July. The job's apt list omits `protobuf-compiler`, so `cargo update && cargo test` dies in the `akri-discovery-utils` build script:

```
thread 'main' panicked at discovery-utils/build.rs:6:10:
failed to compile protos: Could not find `protoc`.
```

Older `tonic` vendored `protoc`; the 0.13 bump expects it on the system, which is why the job started failing rather than having always been broken.

`run-tarpaulin.yml` already installs this exact dependency list plus `protobuf-compiler`, so this is parity with the other workflow that performs the same build.

Worth noting the knock-on: the job runs `./version.sh -u -p` when it finds updates, so while it has been failing no patch bump has been proposed either.

Refs #826.
