### PR TITLE
docs: fix broken CODEOWNERS links in GOVERNANCE.md

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -36,7 +36,7 @@ you can actively engage
   [Slack](https://kubernetes.slack.com/messages/akri)
 
 ### Maintainer
-Maintainers can review and merge pull requests. The [CODEOWNERS](./CODEOWNERS)
+Maintainers can review and merge pull requests. The [CODEOWNERS](.github/CODEOWNERS)
 file defines the current maintainers of the project.
 
 Beyond maintaining Akri's code, maintainers also:
@@ -51,7 +51,7 @@ Regular contributors can **become a maintainer of Akri**. If you frequently find
 yourself doing any combination of commenting on issues, adding thoughts to PRs,
 contributing PRs, writing proposals, attending community meetings, promoting
 discussion on Slack, and so on, you may be a great candidate to become a
-maintainer! Please reach out to one or more [maintainers](./CODEOWNERS) -- we
+maintainer! Please reach out to one or more [maintainers](.github/CODEOWNERS) -- we
 may even ask you first!
 
 #### Emeritus Maintainers


### PR DESCRIPTION
<!--  Thank you for contributing to the Akri repo! Before submitting this PR, please make sure:
1. Read the Contributing Guide before submitting your PR: https://docs.akri.sh/community/contributing
2. Decide whether you need to add any labels to your PR, such as `same version` if the version should not be changed and your change will trigger the version check workflow. This will cause the workflow to automatically succeed: https://github.com/project-akri/akri/blob/main/.github/workflows/check-versioning.yml
3. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context. -->

**What this PR does / why we need it**:

Fixes the two broken `CODEOWNERS` links in `GOVERNANCE.md`.

The links currently point to `./CODEOWNERS`, but the actual file is located at `.github/CODEOWNERS`, causing both links to return 404.

**Special notes for your reviewer**:

This is a documentation-only change. No source code, version, or test files were modified.

**If applicable**:
- [ ] this PR has an associated PR with documentation in [akri-docs](https://github.com/project-akri/akri-docs)
- [ ] this PR contains unit tests
- [ ] added code adheres to standard Rust formatting (`cargo fmt`)
- [ ] code builds properly (`cargo build`)
- [ ] code is free of common mistakes (`cargo clippy`)
- [ ] all Akri tests succeed (`cargo test`)
- [ ] inline documentation builds (`cargo doc`)
- [x] all commits pass the [DCO bot check](https://probot.github.io/apps/dco/) by being signed off -- see the failing DCO check for instructions on how to retroactively sign commits

Closes #847 